### PR TITLE
First pass at Android package rename and file modification. #24

### DIFF
--- a/packages/common/test/fixtures/android-only/android/app/src/main/AndroidManifest.xml
+++ b/packages/common/test/fixtures/android-only/android/app/src/main/AndroidManifest.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.ionic.wowzaStarter">
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.ionic.starter"
+>
     <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:name="com.ionicframework.intune.IntuneApplication">
+    android:allowBackup="true"
+    android:icon="@mipmap/ic_launcher"
+    android:label="@string/app_name"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:supportsRtl="true"
+    android:theme="@style/AppTheme"
+    android:name="com.ionicframework.intune.IntuneApplication"
+  >
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
-            android:name="io.ionic.starter.MainActivity"
-            android:label="@string/title_activity_main"
-            android:theme="@style/AppTheme.NoActionBarLaunch"
-            android:launchMode="singleTask">
+      android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+      android:name="io.ionic.starter.MainActivity"
+      android:label="@string/title_activity_main"
+      android:theme="@style/AppTheme.NoActionBarLaunch"
+      android:launchMode="singleTask"
+    >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -21,13 +26,19 @@
         </activity>
 
         <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
+      android:name="androidx.core.content.FileProvider"
+      android:authorities="${applicationId}.fileprovider"
+      android:exported="false"
+      android:grantUriPermissions="true"
+    >
+            <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/file_paths"
+      />
         </provider>
-        <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
+        <activity
+      android:name="com.microsoft.identity.client.BrowserTabActivity"
+    >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -38,7 +49,11 @@
             Add in your scheme/host from registered redirect URI
             note that the leading "/" is required for android:path
         -->
-                <data android:host="io.ionic.wowzaStarter" android:path="/" android:scheme="msauth" />
+                <data
+          android:host="io.ionic.wowzaStarter"
+          android:path="/"
+          android:scheme="msauth"
+        />
             </intent-filter>
         </activity>
     </application>
@@ -60,7 +75,9 @@
         <!-- Required for API Level 30 to make sure the app can detect browsers that support custom tabs -->
         <!-- https://developers.google.com/web/updates/2020/07/custom-tabs-android-11#detecting_browsers_that_support_custom_tabs -->
         <intent>
-            <action android:name="android.support.customtabs.action.CustomTabsService" />
+            <action
+        android:name="android.support.customtabs.action.CustomTabsService"
+      />
         </intent>
     </queries>
 </manifest>

--- a/packages/common/test/fixtures/ios-and-android/android/app/src/main/AndroidManifest.xml
+++ b/packages/common/test/fixtures/ios-and-android/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.ionic.wowzaStarter"
+  package="io.ionic.starter"
 >
     <application
     android:allowBackup="true"

--- a/packages/project/src/android/gradle-file.ts
+++ b/packages/project/src/android/gradle-file.ts
@@ -255,8 +255,12 @@ export class GradleFile {
 
   async setApplicationId(applicationId: string) {
     const source = await this.getGradleSource();
+
     if (source) {
-      this.vfs.set(this.filename, source.replace(/(applicationId\s+)["'][^"']+["']/, `$1"${applicationId}"`));
+      this.vfs.set(this.filename, source.replace(
+        /(applicationId\s+)["'][^"']+["']/,
+        `$1"${applicationId}"`,
+      ));
     }
   }
 
@@ -269,7 +273,7 @@ export class GradleFile {
       if (!applicationId) {
         return null;
       }
-      
+
       return applicationId[1];
     }
     return null;

--- a/packages/project/src/android/project.ts
+++ b/packages/project/src/android/project.ts
@@ -57,8 +57,16 @@ export class AndroidProject {
    */
   async setPackageName(packageName: string) {
     const oldPackageName = await this.manifest.getDocumentElement()?.getAttribute('package');
+
+    if (packageName === oldPackageName) {
+      return;
+    }
+
     this.manifest.getDocumentElement()?.setAttribute('package', packageName);
     await this.appBuildGradle?.setApplicationId(packageName);
+    this.manifest.setAttrs('manifest/application/activity', {
+      'android:name': `${packageName}.MainActivity`
+    });
 
     if (!this.getAppRoot()) {
       return;

--- a/packages/project/src/android/project.ts
+++ b/packages/project/src/android/project.ts
@@ -1,6 +1,5 @@
 import { join } from 'path';
-import gradleToJs from 'gradle-to-js/lib/parser.js'
-import { pathExists, mkdir, readFile, writeFile } from '@ionic/utils-fs';
+import { pathExists, move, mkdir, mkdirp, readFile, remove, rmdir, writeFile } from '@ionic/utils-fs';
 
 
 import { CapacitorProject } from "../project";
@@ -49,10 +48,59 @@ export class AndroidProject {
     return null;
   }
 
+  /**
+   * Update the Android package name. This renames the package in `AndroidManifest.xml`,
+   * the `applicationId` in `app/build.gradle`, and renames the java
+   * package for the `MainActivity.java` file.
+   * 
+   * This action will mutate the project on disk!
+   */
   async setPackageName(packageName: string) {
+    const oldPackageName = await this.manifest.getDocumentElement()?.getAttribute('package');
     this.manifest.getDocumentElement()?.setAttribute('package', packageName);
     await this.appBuildGradle?.setApplicationId(packageName);
+
+    if (!this.getAppRoot()) {
+      return;
+    }
+
+    const oldPackageParts = oldPackageName?.split('.') ?? [];
+    const newPackageParts = packageName.split('.');
+
+    const sourceDir = join(this.getAppRoot()!, 'src', 'main', 'java');
+    const destDir = join(sourceDir, ...newPackageParts);
+
+    let activityFile = join(sourceDir, ...oldPackageParts, 'MainActivity.java');
+
+    // Make the new directory tree and any missing parents
+    await mkdirp(destDir);
+    // Move the old activity file over
+    await move(activityFile, join(destDir, 'MainActivity.java'));
+
+    // Try to delete the empty directories we left behind, starting
+    // from the deepest
+    let sourceDirLeaf = join(sourceDir, ...oldPackageParts);
+    for (const _ of oldPackageParts) {
+      try {
+        await rmdir(sourceDirLeaf);
+      } catch (ex) {
+        // This will fail if directory is not empty, that's fine, we won't delete those
+      }
+      sourceDirLeaf = join(sourceDirLeaf, '..');
+    }
+
+    // Rename the package in the main source file
+    activityFile = join(sourceDir, ...newPackageParts, 'MainActivity.java');
+    if (await pathExists(activityFile)) {
+      const activitySource = await readFile(activityFile, { encoding: 'utf-8' });
+      const newActivitySource = activitySource?.replace(
+        /(package\s+)[^;]+/,
+        `$1${packageName}`,
+      );
+      await writeFile(activityFile, newActivitySource);
+    }
   }
+
 
   getPackageName() {
     return this.manifest.getDocumentElement()?.getAttribute('package');

--- a/packages/project/test/project.android.test.ts
+++ b/packages/project/test/project.android.test.ts
@@ -51,7 +51,7 @@ describe('project - android', () => {
 
   it('should not error setting same package name', async () => {
     const packageName = project.android?.getPackageName();
-    expect(await project.android?.setPackageName(packageName!)).rejects.toThrow();
+    await project.android?.setPackageName(packageName!);
     expect(project.android?.getPackageName()).toBe(packageName);
   });
 

--- a/packages/project/test/project.android.test.ts
+++ b/packages/project/test/project.android.test.ts
@@ -1,25 +1,35 @@
+import tempy from 'tempy';
+
 import { CapacitorConfig } from "@capacitor/cli";
 import { CapacitorProject } from '../src';
 
 import { join } from 'path';
-import { readFile } from '@ionic/utils-fs';
+import { copy, pathExists, readFile, rm } from '@ionic/utils-fs';
 import { serializeXml } from "../src/util/xml";
 
 describe('project - android', () => {
   let config: CapacitorConfig;
   let project: CapacitorProject;
+  let dir: string;
   beforeEach(async () => {
+    dir = tempy.directory();
+    await copy('../common/test/fixtures/ios-and-android', dir);
+
     config = {
       ios: {
-        path: '../common/test/fixtures/ios-and-android/ios'
+        path: join(dir, 'ios')
       },
       android: {
-        path: '../common/test/fixtures/ios-and-android/android'
+        path: join(dir, 'android')
       }
     }
 
     project = new CapacitorProject(config);
     await project.load();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { force: true, recursive: true });
   });
 
   it('should load project', async () => {
@@ -32,6 +42,27 @@ describe('project - android', () => {
     await project.android?.setPackageName('com.ionicframework.awesome');
     expect(project.android?.getPackageName()).toBe('com.ionicframework.awesome');
     expect(await project.android?.getAppBuildGradle()?.getApplicationId()).toBe('com.ionicframework.awesome');
+    const newSource = await readFile(join(project.config.android?.path!, 'app/src/main/java/com/ionicframework/awesome/MainActivity.java'), { encoding: 'utf-8' });
+    expect(newSource.indexOf('package com.ionicframework.awesome;')).toBe(0);
+    expect(!(await pathExists(join(project.config.android?.path!, 'app/src/main/java/io')))).toBe(true);
+  });
+
+  it('should set package name longer than current package', async () => {
+    await project.android?.setPackageName('com.ionicframework.awesome.long');
+    expect(project.android?.getPackageName()).toBe('com.ionicframework.awesome.long');
+    expect(await project.android?.getAppBuildGradle()?.getApplicationId()).toBe('com.ionicframework.awesome.long');
+    const newSource = await readFile(join(project.config.android?.path!, 'app/src/main/java/com/ionicframework/awesome/long/MainActivity.java'), { encoding: 'utf-8' });
+    expect(newSource.indexOf('package com.ionicframework.awesome.long;')).toBe(0);
+    expect(!(await pathExists(join(project.config.android?.path!, 'app/src/main/java/io')))).toBe(true);
+  });
+
+  it('should set package name shorter than current package', async () => {
+    await project.android?.setPackageName('com.super');
+    expect(project.android?.getPackageName()).toBe('com.super');
+    expect(await project.android?.getAppBuildGradle()?.getApplicationId()).toBe('com.super');
+    const newSource = await readFile(join(project.config.android?.path!, 'app/src/main/java/com/super/MainActivity.java'), { encoding: 'utf-8' });
+    expect(newSource.indexOf('package com.super;')).toBe(0);
+    expect(!(await pathExists(join(project.config.android?.path!, 'app/src/main/java/io')))).toBe(true);
   });
 
   it('should add an attribute on a manifest node', async () => {

--- a/packages/project/test/project.android.test.ts
+++ b/packages/project/test/project.android.test.ts
@@ -45,6 +45,14 @@ describe('project - android', () => {
     const newSource = await readFile(join(project.config.android?.path!, 'app/src/main/java/com/ionicframework/awesome/MainActivity.java'), { encoding: 'utf-8' });
     expect(newSource.indexOf('package com.ionicframework.awesome;')).toBe(0);
     expect(!(await pathExists(join(project.config.android?.path!, 'app/src/main/java/io')))).toBe(true);
+    const activity = project.android?.getAndroidManifest().find('manifest/application/activity');
+    expect(activity?.[0].getAttribute('android:name')).toBe('com.ionicframework.awesome.MainActivity');
+  });
+
+  it('should not error setting same package name', async () => {
+    const packageName = project.android?.getPackageName();
+    expect(await project.android?.setPackageName(packageName!)).rejects.toThrow();
+    expect(project.android?.getPackageName()).toBe(packageName);
   });
 
   it('should set package name longer than current package', async () => {
@@ -54,6 +62,8 @@ describe('project - android', () => {
     const newSource = await readFile(join(project.config.android?.path!, 'app/src/main/java/com/ionicframework/awesome/long/MainActivity.java'), { encoding: 'utf-8' });
     expect(newSource.indexOf('package com.ionicframework.awesome.long;')).toBe(0);
     expect(!(await pathExists(join(project.config.android?.path!, 'app/src/main/java/io')))).toBe(true);
+    const activity = project.android?.getAndroidManifest().find('manifest/application/activity');
+    expect(activity?.[0].getAttribute('android:name')).toBe('com.ionicframework.awesome.long.MainActivity');
   });
 
   it('should set package name shorter than current package', async () => {
@@ -63,6 +73,8 @@ describe('project - android', () => {
     const newSource = await readFile(join(project.config.android?.path!, 'app/src/main/java/com/super/MainActivity.java'), { encoding: 'utf-8' });
     expect(newSource.indexOf('package com.super;')).toBe(0);
     expect(!(await pathExists(join(project.config.android?.path!, 'app/src/main/java/io')))).toBe(true);
+    const activity = project.android?.getAndroidManifest().find('manifest/application/activity');
+    expect(activity?.[0].getAttribute('android:name')).toBe('com.super.MainActivity');
   });
 
   it('should add an attribute on a manifest node', async () => {


### PR DESCRIPTION
This adds to #34 and actually modifies the package name on disk, by modifying the java package folder structure and activity package reference.

See main modifications: https://github.com/ionic-team/capacitor-configure/compare/rename-android-package?expand=1#diff-a23af5d3a45a2fbc5715c4de57d40b67492c35355c3b34a1b2f7700fa5e7524c