### PR TITLE
Support dots in variables

### DIFF
--- a/packages/configure/src/ctx.ts
+++ b/packages/configure/src/ctx.ts
@@ -57,7 +57,7 @@ export function setArguments(ctx: Context, args: any) {
 export function str(ctx: Context, s: string) {
   // Replace any variables in the string, ignoring
   // ones of the type $(blah) which are handled by the platform (i.e. iOS)
-  s = s.replace(/\$[^\(][\w]+/g, (m: string) => {
+  s = s.replace(/\$[^\(][\w.]+/g, (m: string) => {
     const foundVar = ctx.vars[m.slice(1)];
 
     if (foundVar) {


### PR DESCRIPTION
Fixes #43 

The env variable substitution already supports dots, so only change is in replacing vars in strings