### PR TITLE
refactor: update Tempy to resolve deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5517,6 +5517,109 @@
       "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
       "license": "MIT"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -12639,6 +12742,36 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
@@ -15258,6 +15391,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
@@ -17557,6 +17706,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -18676,6 +18835,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-json/node_modules/get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -18972,6 +19138,33 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
@@ -23063,6 +23256,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
@@ -23139,6 +23348,20 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -23523,95 +23746,93 @@
       }
     },
     "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
     "node_modules/tempy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
       "license": "MIT",
       "dependencies": {
-        "del": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/tempy/node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tempy/node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tempy/node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tempy/node_modules/p-map": {
+    "node_modules/tempy/node_modules/crypto-random-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
       "license": "MIT",
       "dependencies": {
-        "aggregate-error": "^3.0.0"
+        "type-fest": "^1.0.1"
       },
       "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tempy/node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -25740,6 +25961,25 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -25981,10 +26221,80 @@
       },
       "devDependencies": {
         "jest": "^27.2.5",
-        "rimraf": "^3.0.2",
-        "tempy": "^1.0.1",
+        "rimraf": "^6.0.1",
+        "tempy": "^3.1.0",
         "ts-jest": "^27.0.7",
         "typescript": "^4.4.4"
+      }
+    },
+    "packages/configure/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/configure/node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/configure/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/configure/node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/gradle-parse": {
@@ -26015,7 +26325,7 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "replace": "^1.1.0",
-        "tempy": "^1.0.1",
+        "tempy": "^3.1.0",
         "tmp": "^0.2.1",
         "ts-node": "^10.2.1",
         "xcode": "^3.0.1",
@@ -26033,7 +26343,7 @@
         "@types/plist": "^3.0.2",
         "@types/slice-ansi": "^5.0.0",
         "jest": "^27.2.5",
-        "rimraf": "^3.0.2",
+        "rimraf": "^6.0.1",
         "ts-jest": "^27.0.7",
         "typescript": "^4.4.4"
       }
@@ -26046,6 +26356,76 @@
       "dependencies": {
         "@xml-tools/parser": "^1.0.11",
         "prettier": ">=2.4.0"
+      }
+    },
+    "packages/project/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/project/node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/project/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/project/node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/website": {

--- a/packages/configure/package.json
+++ b/packages/configure/package.json
@@ -4,7 +4,6 @@
   "description": "Trapeze configuration tool for automatically configuring projects",
   "author": "Ionic Team <hi@ionic.io> (https://ionicframework.com) ",
   "license": "SEE LICENSE",
-  "private": false,
   "files": [
     "bin",
     "dist",
@@ -22,12 +21,12 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "dependencies": {
-    "@trapezedev/project": "7.1.3",
     "@ionic/cli-framework-output": "^2.2.2",
     "@ionic/utils-fs": "^3.1.5",
     "@ionic/utils-subprocess": "^2.1.8",
     "@ionic/utils-terminal": "^2.3.1",
     "@prettier/plugin-xml": "^1.1.0",
+    "@trapezedev/project": "7.1.3",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.0.2",
     "@types/lodash": "^4.14.175",
@@ -66,8 +65,8 @@
   },
   "devDependencies": {
     "jest": "^27.2.5",
-    "rimraf": "^3.0.2",
-    "tempy": "^1.0.1",
+    "rimraf": "^6.0.1",
+    "tempy": "^3.1.0",
     "ts-jest": "^27.0.7",
     "typescript": "^4.4.4"
   },

--- a/packages/configure/test/ops/android.appName.test.ts
+++ b/packages/configure/test/ops/android.appName.test.ts
@@ -1,7 +1,7 @@
 import { copy, readFile, rm } from '@ionic/utils-fs';
 import { XmlFile } from '@trapezedev/project';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { AndroidAppNameOperation, Operation } from '../../src/definitions';
@@ -14,7 +14,7 @@ describe('op: android.appName', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/android.copy.test.ts
+++ b/packages/configure/test/ops/android.copy.test.ts
@@ -1,6 +1,6 @@
 import { copy, readFile, rm } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { AndroidCopyOperation, Operation } from '../../src/definitions';
@@ -13,7 +13,7 @@ describe('op: android.copy', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/android.gradle.test.ts
+++ b/packages/configure/test/ops/android.gradle.test.ts
@@ -2,7 +2,7 @@ import { copy } from '@ionic/utils-fs';
 import { AndroidGradleInjectType } from '@trapezedev/project';
 import { GradleFile } from '@trapezedev/project/dist/android/gradle-file';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { AndroidGradleOperation, Operation } from '../../src/definitions';
@@ -23,7 +23,7 @@ describe('op: android.gradle', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/android.json.test.ts
+++ b/packages/configure/test/ops/android.json.test.ts
@@ -1,7 +1,7 @@
 import { copy } from '@ionic/utils-fs';
 import { JsonFile } from '@trapezedev/project';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { AndroidJsonOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: android.json', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/android.manifest.test.ts
+++ b/packages/configure/test/ops/android.manifest.test.ts
@@ -1,6 +1,6 @@
 import { copy, readFile } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { AndroidXmlOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: android.manifest', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/android.properties.test.ts
+++ b/packages/configure/test/ops/android.properties.test.ts
@@ -1,6 +1,6 @@
 import { copy } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { AndroidJsonOperation, AndroidPropertiesOperation, Operation } from '../../src/definitions';
@@ -11,7 +11,7 @@ describe('op: android.properties', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/android.versionCode.test.ts
+++ b/packages/configure/test/ops/android.versionCode.test.ts
@@ -1,6 +1,6 @@
 import { copy } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: android.versionCode', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/android.xml.test.ts
+++ b/packages/configure/test/ops/android.xml.test.ts
@@ -1,6 +1,6 @@
 import { copy, readFile } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { AndroidXmlOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: android.xml', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.buildVersion.test.ts
+++ b/packages/configure/test/ops/ios.buildVersion.test.ts
@@ -1,6 +1,6 @@
 import { copy, readFile, rm } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosCopyOperation, Operation } from '../../src/definitions';
@@ -13,7 +13,7 @@ describe('op: ios.buildVersion', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.copy.test.ts
+++ b/packages/configure/test/ops/ios.copy.test.ts
@@ -1,6 +1,6 @@
 import { copy, readFile, rm } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosCopyOperation, Operation } from '../../src/definitions';
@@ -13,7 +13,7 @@ describe('op: ios.copy', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.entitlements.test.ts
+++ b/packages/configure/test/ops/ios.entitlements.test.ts
@@ -1,6 +1,6 @@
 import { copy } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosEntitlementsOperation, Operation } from '../../src/definitions';
@@ -11,7 +11,7 @@ describe('op: ios.entitlements', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.json.test.ts
+++ b/packages/configure/test/ops/ios.json.test.ts
@@ -1,7 +1,7 @@
 import { copy } from '@ionic/utils-fs';
 import { JsonFile } from '@trapezedev/project';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosJsonOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: ios.json', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.plist.test.ts
+++ b/packages/configure/test/ops/ios.plist.test.ts
@@ -1,7 +1,7 @@
 import { copy } from '@ionic/utils-fs';
 import { PlistFile } from '@trapezedev/project';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosPlistOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: ios.plist', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.strings.test.ts
+++ b/packages/configure/test/ops/ios.strings.test.ts
@@ -1,7 +1,7 @@
 import { copy } from '@ionic/utils-fs';
 import { StringsFile } from '@trapezedev/project';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosStringsOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: ios.strings', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.xcconfig.test.ts
+++ b/packages/configure/test/ops/ios.xcconfig.test.ts
@@ -1,7 +1,7 @@
 import { copy } from '@ionic/utils-fs';
 import { XCConfigFile } from '@trapezedev/project/src';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosXCConfigOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: ios.strings', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/ios.xml.test.ts
+++ b/packages/configure/test/ops/ios.xml.test.ts
@@ -1,6 +1,6 @@
 import { copy, readFile } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { IosXmlOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: ios.xml', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/project.copy.test.ts
+++ b/packages/configure/test/ops/project.copy.test.ts
@@ -1,6 +1,6 @@
 import { copy, readFile } from '@ionic/utils-fs';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { CopyOperation, Operation } from '../../src/definitions';
@@ -11,7 +11,7 @@ describe('op: project.copy', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/project.json.test.ts
+++ b/packages/configure/test/ops/project.json.test.ts
@@ -1,7 +1,7 @@
 import { copy } from '@ionic/utils-fs';
 import { JsonFile } from '@trapezedev/project';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { JsonOperation, Operation } from '../../src/definitions';
@@ -12,7 +12,7 @@ describe('op: project.json', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/ops/project.xml.test.ts
+++ b/packages/configure/test/ops/project.xml.test.ts
@@ -1,7 +1,7 @@
 import { copy, readFile } from '@ionic/utils-fs';
 import { XmlFile } from '@trapezedev/project';
 import { join } from 'path';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { Context, loadContext } from '../../src/ctx';
 import { XmlOperation, Operation } from '../../src/definitions';
@@ -13,7 +13,7 @@ describe('op: project.xml', () => {
   let ctx: Context;
 
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
 

--- a/packages/configure/test/tasks/run.test.ts
+++ b/packages/configure/test/tasks/run.test.ts
@@ -1,5 +1,5 @@
 import { copy, readFile, rm } from '@ionic/utils-fs';
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 import { join } from 'path';
 import plist from 'plist';
 
@@ -9,7 +9,7 @@ import { loadYamlConfig } from '../../src/yaml-config';
 
 describe('task: run', () => {
   it('should process variables operations', async () => {
-    const dir = tempy.directory();
+    const dir = temporaryDirectory();
     await copy('../common/test/fixtures/basic.yml', join(dir, 'basic.yml'));
 
     const ctx = await loadContext(dir);
@@ -45,7 +45,7 @@ describe('task: run', () => {
   });
 
   it('should handle JSON-values in variables', async () => {
-    const dir = tempy.directory();
+    const dir = temporaryDirectory();
     await copy('../common/test/fixtures/basic.yml', join(dir, 'basic.yml'));
 
     const ctx = await loadContext(dir);
@@ -54,7 +54,7 @@ describe('task: run', () => {
   });
 
   it('should run operations', async () => {
-    const dir = tempy.directory();
+    const dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
     await copy('../common/test/fixtures/basic.yml', join(dir, 'basic.yml'));
@@ -89,7 +89,7 @@ describe('task: run', () => {
   });
 
   it('Should support providing the project root as an arg', async () => {
-    const dir = tempy.directory();
+    const dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/custom-platform-directories', dir);
 
@@ -128,7 +128,7 @@ describe('task: run', () => {
   });
 
   it('should commit operations to filesystem', async () => {
-    const dir = tempy.directory();
+    const dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
     await copy('../common/test/fixtures/basic.yml', join(dir, 'basic.yml'));
@@ -212,7 +212,7 @@ describe('task: run', () => {
 
   // TODO: Separate this out into multiple sub-tests
   it('should commit operations to filesystem directly with y', async () => {
-    const dir = tempy.directory();
+    const dir = temporaryDirectory();
 
     await copy('../common/test/fixtures/ios-and-android', dir);
     await copy('../common/test/fixtures/basic.yml', join(dir, 'basic.yml'));

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -4,7 +4,6 @@
   "description": "Trapeze mobile configuration API for managing projects through code",
   "author": "Ionic Team <hi@ionic.io> (https://ionicframework.com) ",
   "license": "SEE LICENSE",
-  "private": false,
   "files": [
     "dist",
     "README.md"
@@ -36,7 +35,7 @@
     "prettier": "^2.7.1",
     "prompts": "^2.4.2",
     "replace": "^1.1.0",
-    "tempy": "^1.0.1",
+    "tempy": "^3.1.0",
     "tmp": "^0.2.1",
     "ts-node": "^10.2.1",
     "xcode": "^3.0.1",
@@ -71,7 +70,7 @@
     "@types/plist": "^3.0.2",
     "@types/slice-ansi": "^5.0.0",
     "jest": "^27.2.5",
-    "rimraf": "^3.0.2",
+    "rimraf": "^6.0.1",
     "ts-jest": "^27.0.7",
     "typescript": "^4.4.4"
   },

--- a/packages/project/src/android/gradle-file.ts
+++ b/packages/project/src/android/gradle-file.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from 'path';
 import os from 'os';
-import tempy from 'tempy';
+import { temporaryFile } from 'tempy';
 import { pathExists, readFile, writeFile } from '@ionic/utils-fs';
 import { spawnCommand } from '../util/subprocess';
 import { indent } from '../util/text';
@@ -225,7 +225,7 @@ export class GradleFile extends VFSStorable {
     if (!this.tempFile) {
       // If the temp file doesn't exist yet, create it and write the current file source to it
       const gradleContents = await this.getGradleSource();
-      this.tempFile = tempy.file({ extension: 'gradle' });
+      this.tempFile = temporaryFile({ extension: 'gradle' });
       await writeFile(this.tempFile, gradleContents);
     } else if (vfsRef) {
       // Otherwise if it already exists then write the current vfs data to it

--- a/packages/project/test/project.android.test.ts
+++ b/packages/project/test/project.android.test.ts
@@ -1,4 +1,4 @@
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { MobileProject, XmlFile } from '../src';
 
@@ -13,7 +13,7 @@ describe('project - android', () => {
   let project: MobileProject;
   let dir: string;
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
     await copy('../common/test/fixtures/ios-and-android', dir);
 
     config = {
@@ -357,7 +357,7 @@ describe('project - android - capacitor v5', () => {
   let project: MobileProject;
   let dir: string;
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
     await copy('../common/test/fixtures/cap-v5', dir);
 
     config = {

--- a/packages/project/test/project.ios.test.ts
+++ b/packages/project/test/project.ios.test.ts
@@ -1,4 +1,4 @@
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 import { join } from 'path';
 import { copy, pathExists, readFile, rm } from '@ionic/utils-fs';
 import { MobileProject, StringsFile, XCConfigFile, XmlFile } from '../src';
@@ -11,7 +11,7 @@ describe('project - ios standard', () => {
 
   let dir: string;
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
     await copy('../common/test/fixtures/ios-and-android', dir);
 
     config = {
@@ -446,7 +446,7 @@ describe('ios - no info plist case', () => {
   let project: MobileProject;
   let dir: string;
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
     await copy('../common/test/fixtures/ios-no-info-plist', dir);
 
     config = {
@@ -478,7 +478,7 @@ describe('ios - empty template case', () => {
   let project: MobileProject;
   let dir: string;
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
     await copy('../common/test/fixtures/ios-no-current-project-version', dir);
 
     config = {
@@ -505,7 +505,7 @@ describe('ios - issue #83', () => {
   let project: MobileProject;
   let dir: string;
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
     await copy('../common/test/fixtures/ios-cfbundleversion-pbx-83', dir);
 
     config = {

--- a/packages/project/test/project.test.ts
+++ b/packages/project/test/project.test.ts
@@ -1,4 +1,4 @@
-import tempy from 'tempy';
+import { temporaryDirectory } from 'tempy';
 
 import { MobileProject, XmlFile } from '../src';
 
@@ -13,7 +13,7 @@ describe('project - base', () => {
   let project: MobileProject;
   let dir: string;
   beforeEach(async () => {
-    dir = tempy.directory();
+    dir = temporaryDirectory();
     await copy('../common/test/fixtures/ios-and-android', dir);
 
     config = {


### PR DESCRIPTION
Tempy appears to be the source of a lot of deprecation warnings when adding Trapeze to other projects. This updates the package to the latest version, and replaces the old method names with the new versions. It also bumps rimraf to the latest version as well.