### PR TITLE
fix(ci): use scoped package names as release-please components

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,14 @@
   "separate-pull-requests": false,
   "plugins": ["node-workspace"],
   "packages": {
-    "packages/gradle-parse": {},
-    "packages/project": {},
-    "packages/configure": {}
+    "packages/gradle-parse": {
+      "component": "@trapezedev/gradle-parse"
+    },
+    "packages/project": {
+      "component": "@trapezedev/project"
+    },
+    "packages/configure": {
+      "component": "@trapezedev/configure"
+    }
   }
 }


### PR DESCRIPTION
Fixes the component names in `release-please-config.json`. Without this, [#239](https://github.com/ionic-team/trapeze/pull/239) proposes changelogs crediting each package with commits that shipped years ago.

## Problem

The `node` release type derives a component from the package name with the npm scope stripped, so `@trapezedev/project` becomes `project`. Release-please therefore looked for a `project@7.1.5` tag. The actual tag is `@trapezedev/project@7.1.5`, so no match was found.

With no previous release to anchor to, it fell back to scanning the entire history — as its own diagnostic describes:

> No latest release found for path: `${path}`, component: `${component}`, but a previous version was specified in the manifest.

Two consequences:

1. **Polluted changelogs.** [#239](https://github.com/ionic-team/trapeze/pull/239) credits `7.1.6` with commits from the 7.0.x line — #83, #125, #187, #224, the `cross-fetch` replacement, the `CFBundleDisplayName` fix — all released long ago. Only the `fs-extra` fix genuinely belongs.
2. **Broken tag continuity.** New tags would be `project@7.1.6`, whereas every existing tag uses `@trapezedev/project@7.1.5`. The config sets `tag-separator` and `include-v-in-tag` specifically to preserve that format, and the wrong component defeats it.

## Fix

Set `component` explicitly for each package so it keeps the full scoped name.

Verified that all three resulting tag names exist in the repository, and that release-please's tag regex parses a scoped component correctly — the greedy component group takes the last `@` before the version, so `@trapezedev/project@7.1.5` yields component `@trapezedev/project` and version `7.1.5`.

## After merging

Release-please re-runs on `main` and force-updates its own branch, so [#239](https://github.com/ionic-team/trapeze/pull/239) should regenerate with correctly scoped changelogs. If it does not, closing it and deleting `release-please--branches--main` forces a clean rebuild.

Do not merge [#239](https://github.com/ionic-team/trapeze/pull/239) before this lands — doing so would write the incorrect history into both changelogs permanently and create mis-named tags.