### PR TITLE
fix(ci): scope release build to published packages and link versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,11 @@ jobs:
         run: npm install -g npm@latest
       - if: ${{ steps.release-please.outputs.releases_created == 'true' }}
         run: npm ci
+      # Scoped to the published packages; the private website is covered by CI
       - if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-        run: npm run build
+        run: npm run build -- --filter='@trapezedev/*'
       - if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-        run: npm test
+        run: npm test -- --filter='@trapezedev/*'
       # Published in dependency order: gradle-parse <- project <- configure
       - name: Publish @trapezedev/gradle-parse
         if: ${{ steps.release-please.outputs['packages/gradle-parse--release_created'] == 'true' }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,17 @@
   "include-v-in-tag": false,
   "tag-separator": "@",
   "separate-pull-requests": false,
-  "plugins": ["node-workspace"],
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "trapeze",
+      "components": ["@trapezedev/gradle-parse", "@trapezedev/project", "@trapezedev/configure"]
+    }
+  ],
   "packages": {
     "packages/gradle-parse": {
       "component": "@trapezedev/gradle-parse"


### PR DESCRIPTION
Fixes the [failed release run](https://github.com/ionic-team/trapeze/actions/runs/31864038164) and restores a single shared version across all packages.

## Release build no longer builds the website

The release job ran `npm run build` across every workspace, including `configure-website`. That package is `private` and never published, but its `sharp` dependency cannot load its native binary on Node 24:

```
Could not load the "sharp" module using the linux-x64 runtime
Node version: v24.19.0
```

The build failed, and because the publish steps run after it, `7.1.6` was tagged and released on GitHub but never reached npm. A private docs site should not be able to block a package publish.

The build and test steps are now scoped with `--filter='@trapezedev/*'`, which selects exactly the three published packages. CI still builds and tests every workspace on each pull request, so website coverage is unchanged.

`NODE_VERSION` stays at 24, which npm OIDC trusted publishing requires. Note separately that the website cannot build on Node 24 at all — raising `ci.yml` from Node 20 would break it.

## Single shared version across packages

Before the migration, changesets used a `fixed` group so all three packages always shared one version. Independent versioning left `@trapezedev/gradle-parse` at `7.1.5` while the other two moved to `7.1.6`, which does not match how the project is documented or how users refer to a Trapeze version.

The `linked-versions` plugin restores the previous behaviour: when any package is released, all three are updated to the highest resulting version.

Per the [manifest releaser docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#linked-versions), a workspace plugin combined with `linked-versions` must skip its own internal merge, so `node-workspace` is now configured with `merge: false`. Plugin order is significant and follows the documented example.

## Follow-up outside this PR

`7.1.6` is tagged and released on GitHub but absent from npm. Release-please will not re-announce an existing release, so a re-run cannot publish it — it needs a one-time manual `npm publish` for `@trapezedev/project` and `@trapezedev/configure`. Every release after that goes through CI.

## Verification

Confirmed the filter resolves to `@trapezedev/configure`, `@trapezedev/gradle-parse`, and `@trapezedev/project`, with `configure-website` absent from the task graph. Filtered build and test both pass locally.