### PR TITLE
fix(deps): remove unused `@types/fs-extra`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6946,15 +6946,6 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/hast": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
@@ -23210,7 +23201,6 @@
         "@ionic/utils-terminal": "^2.3.1",
         "@prettier/plugin-xml": "^1.1.0",
         "@trapezedev/project": "^7.1.6",
-        "@types/fs-extra": "^9.0.13",
         "@types/lodash": "^4.14.175",
         "@types/plist": "^3.0.2",
         "@types/prompts": "^2.0.14",
@@ -23489,7 +23479,6 @@
       "devDependencies": {
         "@types/cross-spawn": "^6.0.2",
         "@types/diff": "^5.0.2",
-        "@types/fs-extra": "^9.0.13",
         "@types/ini": "^1.3.31",
         "@types/lodash": "^4.14.175",
         "@types/plist": "^3.0.2",

--- a/packages/configure/package.json
+++ b/packages/configure/package.json
@@ -27,7 +27,6 @@
     "@ionic/utils-terminal": "^2.3.1",
     "@prettier/plugin-xml": "^1.1.0",
     "@trapezedev/project": "^7.1.6",
-    "@types/fs-extra": "^9.0.13",
     "@types/lodash": "^4.14.175",
     "@types/plist": "^3.0.2",
     "@types/prompts": "^2.0.14",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",
     "@types/diff": "^5.0.2",
-    "@types/fs-extra": "^9.0.13",
     "@types/ini": "^1.3.31",
     "@types/lodash": "^4.14.175",
     "@types/plist": "^3.0.2",

--- a/packages/project/tsconfig.json
+++ b/packages/project/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "target": "es2019",
-    "types": ["node", "cross-spawn", "diff", "fs-extra", "ini", "lodash", "plist", "prettier"]
+    "types": ["node", "cross-spawn", "diff", "ini", "lodash", "plist", "prettier"]
   },
   "files": ["src/index.ts"],
   "include": ["/src/**/*.ts", "**/src/**/*.ts", "/src/**/*.d.ts"]


### PR DESCRIPTION
Removes a dependency that nothing uses any more, and exercises the release pipeline end to end.

## Change

Nothing imports `fs-extra` since [#238](https://github.com/ionic-team/trapeze/pull/238) replaced its single use with the built-in `fs/promises`, so the type definitions are dead in both packages that declared them:

- `@trapezedev/configure` listed it under `dependencies` rather than `devDependencies`, so it was published to every consumer despite being types-only.
- `@trapezedev/project` listed it under `devDependencies`. Removing it there also requires dropping `fs-extra` from the `types` array in `packages/project/tsconfig.json` — TypeScript resolves that array eagerly and fails with `TS2688: Cannot find type definition file for 'fs-extra'` otherwise.

`@types/fs-extra` remains present transitively through `@ionic/utils-fs`, which is unaffected.

## Why now

This is the first commit since the migration that both uses a releasable type and touches a package directory, so it is also the first real test of the new pipeline. Release-please assigns commits to packages by file path, which is why the preceding CI and config fixes correctly produced no release.

Merging this should open a release PR proposing all three packages at the same version, confirming that the `linked-versions` plugin added in [#241](https://github.com/ionic-team/trapeze/pull/241) works and pulling `@trapezedev/gradle-parse` up from `7.1.5`.

That release also carries the `fs-extra` fix to npm. It has been on `main` unpublished since the `7.1.6` release run failed on the website build, and `7.1.6` will simply never exist on npm.

The `7.1.6` tags and GitHub releases should be left in place — release-please anchors the next release to them.

## Verification

Full build across all four workspaces including the website, and the full test suite: `project` 20 files / 124 tests, `configure` 23 files / 63 tests.