### PR TITLE
fix(configure): stop dropping keys next to targets/builds and interpolate map keys

### DIFF
--- a/packages/common/test/fixtures/ios.merge.keys.yml
+++ b/packages/common/test/fixtures/ios.merge.keys.yml
@@ -1,0 +1,10 @@
+platforms:
+  ios:
+    targets:
+      App:
+        builds:
+          Debug: &shared
+            bundleId: com.ionicframework.testBundle
+          Release:
+            <<: *shared
+            displayName: My Awesome App

--- a/packages/common/test/fixtures/ios.shared.targets.builds.yml
+++ b/packages/common/test/fixtures/ios.shared.targets.builds.yml
@@ -1,0 +1,9 @@
+platforms:
+  ios:
+    bundleId: com.ionicframework.testBundle
+    targets:
+      App:
+        version: 16.4
+        builds:
+          Debug:
+            displayName: My Awesome App

--- a/packages/common/test/fixtures/ios.var.keys.yml
+++ b/packages/common/test/fixtures/ios.var.keys.yml
@@ -3,6 +3,9 @@ vars:
     default: com.ionicframework.testBundle
   PROFILE:
     default: My iOS Profile
+  PROFILE_MAP:
+    default:
+      com.ionicframework.testBundle: My iOS Profile
 platforms:
   ios:
     targets:
@@ -12,3 +15,5 @@ platforms:
             entries:
               - provisioningProfiles:
                   $BUNDLE_ID: $PROFILE
+              - serializedKeys:
+                  $PROFILE_MAP: My iOS Profiles

--- a/packages/common/test/fixtures/ios.var.keys.yml
+++ b/packages/common/test/fixtures/ios.var.keys.yml
@@ -1,0 +1,14 @@
+vars:
+  BUNDLE_ID:
+    default: com.ionicframework.testBundle
+  PROFILE:
+    default: My iOS Profile
+platforms:
+  ios:
+    targets:
+      App:
+        plist:
+          - file: exportOptions.plist
+            entries:
+              - provisioningProfiles:
+                  $BUNDLE_ID: $PROFILE

--- a/packages/configure/src/op.ts
+++ b/packages/configure/src/op.ts
@@ -46,28 +46,24 @@ function createIosPlatform(platform: string, platformEntry: any) {
     return [];
   }
 
-  if (typeof platformEntry.targets !== 'undefined') {
-    return createIosPlatformTargets(platform, platformEntry);
-  } else {
-    return Object.keys(platformEntry || {})
-      .map(op =>
-        createIosOperation({
-          platform,
-          target: null,
-          build: null,
-          op,
-          opEntry: platformEntry[op],
-        }),
-      )
-      .flat();
-  }
+  // Platform-wide operations run first so target-specific ones win on conflict
+  return Object.keys(platformEntry)
+    .filter(op => op !== 'targets')
+    .map(op =>
+      createIosOperation({
+        platform,
+        target: null,
+        build: null,
+        op,
+        opEntry: platformEntry[op],
+      }),
+    )
+    .concat(createIosPlatformTargets(platform, platformEntry.targets));
 }
 
-function createIosPlatformTargets(platform: string, platformEntry: any) {
-  return Object.keys(platformEntry.targets || {})
-    .map(target =>
-      createIosPlatformTarget(platform, target, platformEntry.targets[target]),
-    )
+function createIosPlatformTargets(platform: string, targets: any) {
+  return Object.keys(targets || {})
+    .map(target => createIosPlatformTarget(platform, target, targets[target]))
     .flat();
 }
 
@@ -76,39 +72,28 @@ function createIosPlatformTarget(
   target: string,
   targetEntry: any,
 ) {
-  if (typeof targetEntry.builds !== 'undefined') {
-    return createIosPlatformBuilds(platform, target, targetEntry);
-  } else {
-    return Object.keys(targetEntry || {})
-      .map(op =>
-        createIosOperation({
-          platform,
-          target,
-          build: null,
-          op,
-          opEntry: targetEntry[op],
-        }),
-      )
-      .flat();
-  }
+  // Target-wide operations run first so build-specific ones win on conflict
+  return Object.keys(targetEntry || {})
+    .filter(op => op !== 'builds')
+    .map(op =>
+      createIosOperation({
+        platform,
+        target,
+        build: null,
+        op,
+        opEntry: targetEntry[op],
+      }),
+    )
+    .concat(createIosPlatformBuilds(platform, target, targetEntry?.builds));
 }
 
 function createIosPlatformBuilds(
   platform: string,
   target: string,
-  targetEntry: any,
+  builds: any,
 ) {
-  return Object.keys(targetEntry.builds || {})
-    .map(
-      build =>
-        createIosPlatformBuild(
-          platform,
-          target,
-          build,
-          targetEntry.builds[build],
-        ),
-      // createIosPlatformBuild({ platform, target, build, buildEntry: targetEntry.builds[build] })
-    )
+  return Object.keys(builds || {})
+    .map(build => createIosPlatformBuild(platform, target, build, builds[build]))
     .flat();
 }
 

--- a/packages/configure/src/yaml-config.ts
+++ b/packages/configure/src/yaml-config.ts
@@ -121,7 +121,9 @@ function interpolateVarsInValue(ctx: Context, val: any) {
 }
 
 // Array indices are passed through, and a key resolving to a JSON-valued
-// variable is coerced back to a string since it has to stay usable as a key
+// variable is coerced back to a string since it has to stay usable as a key.
+// Objects and arrays are serialized the same way `str` serializes them when
+// they are embedded in a string
 function interpolateKey(ctx: Context, key: string | number) {
   if (typeof key !== 'string') {
     return key;
@@ -129,5 +131,11 @@ function interpolateKey(ctx: Context, key: string | number) {
 
   const interped = str(ctx, key);
 
-  return typeof interped === 'string' ? interped : String(interped);
+  if (typeof interped === 'string') {
+    return interped;
+  }
+
+  return typeof interped === 'object'
+    ? JSON.stringify(interped)
+    : String(interped);
 }

--- a/packages/configure/src/yaml-config.ts
+++ b/packages/configure/src/yaml-config.ts
@@ -1,6 +1,6 @@
 import yaml from 'yaml';
 
-import { clone, each } from 'lodash';
+import { clone, each, omit } from 'lodash';
 
 import { readFile } from '@ionic/utils-fs';
 
@@ -19,6 +19,7 @@ export async function loadYamlConfig(
   const contents = await readFile(filename, { encoding: 'utf-8' });
   const parsed = yaml.parse(contents, {
     prettyErrors: true,
+    merge: true,
   });
 
   if (!parsed) {
@@ -80,25 +81,53 @@ function interpolateVars(ctx: Context, yaml: YamlFile) {
     ...ctx.vars,
   };
 
-  return interpolateVarsInTree(ctx, yaml);
+  const config = interpolateVarsInTree(ctx, omit(yaml, 'vars'));
+
+  // Variable declarations are left alone so their names aren't interpolated
+  return vars ? { ...config, vars } : config;
 }
 
 function interpolateVarsInTree(ctx: Context, yaml: YamlFile) {
   const newObject = clone(yaml);
 
   each(yaml, (val, key) => {
-    if (typeof val === 'string') {
-      const interped = str(ctx, val);
-      if (typeof interped === 'object') {
-        // Recur into the new object value to interp any sub-fields
-        newObject[key] = interpolateVarsInTree(ctx, interped);
-      } else {
-        newObject[key] = interped;
-      }
-    } else if (typeof val === 'object' || Array.isArray(val)) {
-      newObject[key] = interpolateVarsInTree(ctx, val);
+    const newKey = interpolateKey(ctx, key);
+
+    if (newKey !== key) {
+      delete newObject[key];
     }
+
+    newObject[newKey] = interpolateVarsInValue(ctx, val);
   });
 
   return newObject;
+}
+
+function interpolateVarsInValue(ctx: Context, val: any) {
+  if (typeof val === 'string') {
+    const interped = str(ctx, val);
+
+    // Recur into the new object value to interp any sub-fields
+    return typeof interped === 'object'
+      ? interpolateVarsInTree(ctx, interped)
+      : interped;
+  }
+
+  if (typeof val === 'object') {
+    return interpolateVarsInTree(ctx, val);
+  }
+
+  return val;
+}
+
+// Array indices are passed through, and a key resolving to a JSON-valued
+// variable is coerced back to a string since it has to stay usable as a key
+function interpolateKey(ctx: Context, key: string | number) {
+  if (typeof key !== 'string') {
+    return key;
+  }
+
+  const interped = str(ctx, key);
+
+  return typeof interped === 'string' ? interped : String(interped);
 }

--- a/packages/configure/test/config.test.ts
+++ b/packages/configure/test/config.test.ts
@@ -28,6 +28,19 @@ describe('config loading', () => {
     });
   });
 
+  it('should serialize JSON-valued variables used as map keys', async () => {
+    const parsed = await loadYamlConfig(
+      ctx,
+      '../common/test/fixtures/ios.var.keys.yml',
+    );
+
+    expect(parsed.platforms.ios.targets.App.plist[0].entries[1]).toEqual({
+      serializedKeys: {
+        '{"com.ionicframework.testBundle":"My iOS Profile"}': 'My iOS Profiles',
+      },
+    });
+  });
+
   it('should keep variable declarations intact', async () => {
     const parsed = await loadYamlConfig(
       ctx,

--- a/packages/configure/test/config.test.ts
+++ b/packages/configure/test/config.test.ts
@@ -14,4 +14,29 @@ describe('config loading', () => {
     );
     expect(parsed).not.toBeUndefined();
   });
+
+  it('should interpolate variables used as map keys', async () => {
+    const parsed = await loadYamlConfig(
+      ctx,
+      '../common/test/fixtures/ios.var.keys.yml',
+    );
+
+    expect(parsed.platforms.ios.targets.App.plist[0].entries[0]).toEqual({
+      provisioningProfiles: {
+        'com.ionicframework.testBundle': 'My iOS Profile',
+      },
+    });
+  });
+
+  it('should keep variable declarations intact', async () => {
+    const parsed = await loadYamlConfig(
+      ctx,
+      '../common/test/fixtures/ios.var.keys.yml',
+    );
+
+    expect(parsed.vars).toMatchObject({
+      BUNDLE_ID: { default: 'com.ionicframework.testBundle' },
+      PROFILE: { default: 'My iOS Profile' },
+    });
+  });
 });

--- a/packages/configure/test/op.test.ts
+++ b/packages/configure/test/op.test.ts
@@ -164,6 +164,63 @@ describe('operation processing', () => {
       ] as Operation[]);
     });
 
+    it('should process ios operations defined next to targets and builds', async () => {
+      const makeOp = (
+        name: string,
+        value: any,
+        iosTarget: string | null,
+        iosBuild: string | null,
+      ): Operation => ({
+        id: `ios.${name}`,
+        platform: 'ios',
+        name,
+        iosTarget,
+        iosBuild,
+        value,
+        displayText: expect.anything(),
+      });
+      const parsed = await loadYamlConfig(
+        ctx,
+        '../common/test/fixtures/ios.shared.targets.builds.yml',
+      );
+
+      const processed = processOperations(parsed);
+
+      expect(processed).toMatchObject([
+        makeOp('bundleId', 'com.ionicframework.testBundle', null, null),
+        makeOp('version', 16.4, 'App', null),
+        makeOp('displayName', 'My Awesome App', 'App', 'Debug'),
+      ] as Operation[]);
+    });
+
+    it('should process ios operations shared through yaml merge keys', async () => {
+      const makeOp = (
+        name: string,
+        value: any,
+        iosBuild: string,
+      ): Operation => ({
+        id: `ios.${name}`,
+        platform: 'ios',
+        name,
+        iosTarget: 'App',
+        iosBuild,
+        value,
+        displayText: expect.anything(),
+      });
+      const parsed = await loadYamlConfig(
+        ctx,
+        '../common/test/fixtures/ios.merge.keys.yml',
+      );
+
+      const processed = processOperations(parsed);
+
+      expect(processed).toMatchObject([
+        makeOp('bundleId', 'com.ionicframework.testBundle', 'Debug'),
+        makeOp('bundleId', 'com.ionicframework.testBundle', 'Release'),
+        makeOp('displayName', 'My Awesome App', 'Release'),
+      ] as Operation[]);
+    });
+
     it('should process ios operations with no targets and no builds', async () => {
       const makeOp = (name: string, value: any): Operation => ({
         id: `ios.${name}`,

--- a/packages/website/docs/operations/getting-started.md
+++ b/packages/website/docs/operations/getting-started.md
@@ -45,6 +45,8 @@ Configuration files are written in YAML. New to YAML? Read [Learn YAML in five m
 
 See an [Example Yaml Configuration](https://github.com/ionic-team/capacitor-configure/blob/main/examples/basic.yml) for a real-world example using many of the supported features.
 
+YAML anchors and merge keys (`<<`) are supported and can be used to share configuration between sections.
+
 ## Variables and Environment Variables
 
 Variables defined in the yaml `vars` section can be automatically supplied through environment variables of the same name, or interactively input by the user if not found in the environment and lacking a default value.
@@ -84,6 +86,22 @@ platforms:
       App:
         entitlements:
           - keychain-access-groups: $KEYCHAIN_GROUPS
+```
+
+### Variables as keys
+
+Variables can also be used as map keys, which is useful for configuration that is keyed by a value such as the bundle id:
+
+```yaml
+platforms:
+  ios:
+    targets:
+      App:
+        plist:
+          - file: exportOptions.plist
+            entries:
+              - provisioningProfiles:
+                  $BUNDLE_ID: $PROVISIONING_PROFILE
 ```
 
 ### Variable types

--- a/packages/website/docs/operations/ios.md
+++ b/packages/website/docs/operations/ios.md
@@ -49,6 +49,20 @@ platforms:
             # Operations for the App target and Release build
 ```
 
+Operations can be defined next to `targets` and `builds` to share them. Operations next to `targets` apply to every target, operations next to `builds` apply to every build of that target. They run before the more specific ones, so a target or build can override a shared value:
+
+```yaml
+platforms:
+  ios:
+    bundleId: io.ionic.myApp # Every target
+    targets:
+      App:
+        version: 1.0.0 # Every build of the App target
+        builds:
+          Debug:
+            bundleId: io.ionic.myApp.debug # Overrides the shared bundleId
+```
+
 ### `version`
 
 Updates the human-readable version for the given target and build:

--- a/packages/website/docs/operations/ios.md
+++ b/packages/website/docs/operations/ios.md
@@ -49,18 +49,18 @@ platforms:
             # Operations for the App target and Release build
 ```
 
-Operations can be defined next to `targets` and `builds` to share them. Operations next to `targets` apply to every target, operations next to `builds` apply to every build of that target. They run before the more specific ones, so a target or build can override a shared value:
+Operations can be defined next to `targets` and `builds` to share them. Operations next to `targets` apply to the inferred app target and all of its build types, operations next to `builds` apply to all build types of that target. They run before the more specific ones, so a target or build can override a shared value:
 
 ```yaml
 platforms:
   ios:
-    bundleId: io.ionic.myApp # Every target
+    bundleId: io.ionic.myApp # App target, all build types
     targets:
       App:
-        version: 1.0.0 # Every build of the App target
+        version: 1.0.0 # App target, all build types
         builds:
           Debug:
-            bundleId: io.ionic.myApp.debug # Overrides the shared bundleId
+            bundleId: io.ionic.myApp.debug # Overrides the shared bundleId for Debug
 ```
 
 ### `version`


### PR DESCRIPTION
## Problem

Two verified defects in the YAML configuration pipeline:

1. **Keys next to `targets:` / `builds:` are silently dropped** (#221). `createIosPlatform()` / `createIosPlatformTarget()` returned early when `targets` / `builds` was present, so e.g. a platform-level `bundleId` next to `targets:` never produced an operation — shared configuration had to be duplicated under every build. YAML merge keys (`<<:`) as a workaround also failed because merge-key resolution is opt-in in the bundled `yaml` parser.
2. **Map keys are never interpolated** (#232). `interpolateVarsInTree()` interpolated values only, so `$BUNDLE_ID:` used as a plist dict key (e.g. `provisioningProfiles` in an exportOptions.plist) was written literally.

## Fix

- `packages/configure/src/op.ts`: emit ops for all sibling keys, then recurse into `targets` / `builds`; generic ops are emitted before specific ones so specific ops win on conflict.
- `packages/configure/src/yaml-config.ts`: enable `merge: true` in `yaml.parse`; interpolate map keys through `str()` (numeric array indices pass through, non-string results are coerced), with the top-level `vars` block excluded so declarations keep their names.
- Docs: shared-ops example in `operations/ios.md`, merge-key + variables-as-keys notes in `operations/getting-started.md`.

## Verification

- New tests fail without the fixes (verified by stashing): sibling-key flattening (platform/target/build levels), merge-key resolution, `$VAR` map keys, untouched `vars` declarations. New fixtures: `ios.shared.targets.builds.yml`, `ios.merge.keys.yml`, `ios.var.keys.yml`.
- Full suites pass: `packages/project` 124 tests, `packages/configure` 68 tests (against freshly built project).
- Note: root `npm run build` fails on `configure-website#build` in the local environment due to a missing `sharp` native binary — pre-existing on pristine main, unrelated to this change.

Closes #221
Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
