### PR TITLE
fix(project): match unprefixed XPath targets in documents with a default namespace

### DIFF
--- a/packages/common/test/fixtures/issues/190/config.xml
+++ b/packages/common/test/fixtures/issues/190/config.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="io.ionic.starter" version="0.1.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>capacitor-configure-test</name>
+    <content src="index.html" />
+    <allow-navigation href="https://*/*" />
+    <cdv:plugin name="cordova-plugin-test" />
+</widget>

--- a/packages/project/src/xml.ts
+++ b/packages/project/src/xml.ts
@@ -70,8 +70,11 @@ export class XmlFile extends VFSStorable {
   /**
    * Selects the nodes matching an XPath node-set expression.
    *
-   * `allowAnyNamespaceForNoPrefix` lets an unprefixed name test match elements in the
-   * document's default namespace, which plain XPath 1.0 would never match.
+   * `allowAnyNamespaceForNoPrefix` lets an unprefixed name test match elements in any
+   * namespace, not just the document's default one. That is more permissive than plain
+   * XPath 1.0, but acceptable here: prefixed name tests still resolve through the
+   * namespaces collected from the root element, and without it an unprefixed target
+   * matches nothing at all in a document that declares a default namespace.
    */
   private select(expression: string, doc: Document): Node[] {
     return (xpath as any).parse(expression).select({

--- a/packages/project/src/xml.ts
+++ b/packages/project/src/xml.ts
@@ -1,5 +1,5 @@
 import { formatXml, parseXml, parseXmlFragment, parseXmlString, serializeXml, writeXml } from './util/xml';
-import xpath, { XPathSelect } from 'xpath';
+import xpath from 'xpath';
 import { xml2js, js2xml } from 'xml-js';
 import { VFS, VFSFile, VFSStorable } from './vfs';
 import { readFile } from 'fs/promises';
@@ -9,7 +9,7 @@ import { assertParentDirs } from './util/fs';
 export class XmlFile extends VFSStorable {
   private doc: Document | null = null;
 
-  private select: XPathSelect = xpath.select;
+  private namespaces: { [ns: string]: string } = {};
 
   constructor(private path: string, private vfs: VFS) {
     super();
@@ -46,7 +46,7 @@ export class XmlFile extends VFSStorable {
         }
       }
       Logger.v('xml', 'load', `Found root namespaces in XML file:`, Object.values(namespaces).join(' '));
-      this.select = xpath.useNamespaces(namespaces);
+      this.namespaces = namespaces;
     }
   }
 
@@ -67,12 +67,36 @@ export class XmlFile extends VFSStorable {
     return attrs.join(' ');
   }
 
+  /**
+   * Selects the nodes matching an XPath node-set expression.
+   *
+   * `allowAnyNamespaceForNoPrefix` lets an unprefixed name test match elements in the
+   * document's default namespace, which plain XPath 1.0 would never match.
+   */
+  private select(expression: string, doc: Document): Node[] {
+    return (xpath as any).parse(expression).select({
+      node: doc,
+      namespaces: this.namespaces,
+      allowAnyNamespaceForNoPrefix: true,
+    });
+  }
+
+  private selectTargetNodes(target: string, doc: Document): Element[] {
+    const nodes = this.select(target, doc) as Element[];
+
+    if (!nodes.length) {
+      Logger.warn(`No nodes in ${this.path} match the target '${target}'`);
+    }
+
+    return nodes;
+  }
+
   find(target: string): Element[] | null {
     if (!this.doc) {
       return null;
     }
 
-    return this.select?.(target, this.doc) as Element[];
+    return this.select(target, this.doc) as Element[];
   }
 
   deleteNodes(target: string) {
@@ -82,7 +106,7 @@ export class XmlFile extends VFSStorable {
 
     Logger.v('xml', 'deleteNodes', `at ${target}`);
 
-    const nodes = this.select?.(target, this.doc) as Element[];
+    const nodes = this.selectTargetNodes(target, this.doc);
     nodes.forEach(n => n.parentNode?.removeChild(n));
 
     this.vfs.set(this.path, this);
@@ -93,7 +117,7 @@ export class XmlFile extends VFSStorable {
       return;
     }
 
-    const nodes = this.select?.(target, this.doc) as Element[];
+    const nodes = this.selectTargetNodes(target, this.doc);
     nodes.forEach(n => attributes.forEach(a => n.removeAttribute(a)));
 
     Logger.v('xml', 'deleteAttributes', `at ${target}`);
@@ -111,7 +135,7 @@ export class XmlFile extends VFSStorable {
       return;
     }
 
-    const nodes = this.select?.(target, this.doc) as Element[];
+    const nodes = this.selectTargetNodes(target, this.doc);
     const docNodes = Array.from(parseXmlFragment(fragment, this.getNamespaceAttrs()));
 
     Logger.v('xml', 'injectFragment', `at ${target}`);
@@ -132,7 +156,7 @@ export class XmlFile extends VFSStorable {
     }
 
     // Get the target element
-    const node = this.select?.(target, this.doc) as Element[];
+    const node = this.selectTargetNodes(target, this.doc);
 
     Logger.v('xml', 'mergeFragment', `at ${target}`);
 
@@ -208,7 +232,7 @@ export class XmlFile extends VFSStorable {
       return;
     }
 
-    const nodes = this.select?.(target, this.doc) as Element[];
+    const nodes = this.selectTargetNodes(target, this.doc);
     const parsed = parseXmlString(fragment);
 
     nodes.forEach(n => {
@@ -238,7 +262,7 @@ export class XmlFile extends VFSStorable {
 
     Logger.v('xml', 'setAttrs', `at ${this.path} - ${target}`);
 
-    const nodes = this.select?.(target, this.doc) ?? [];
+    const nodes = this.selectTargetNodes(target, this.doc);
     nodes.forEach((n: any) => {
       Object.keys(attrs).forEach(attr => {
         n.setAttribute(attr, attrs[attr]);

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -174,12 +174,11 @@ describe('xml file', () => {
 
   it('Should warn when a target matches no nodes', async () => {
     const warn = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+    onTestFinished(() => warn.mockRestore());
 
     file.setAttrs('missing', { test: 'thing' });
 
     expect(warn).toHaveBeenCalledWith(expect.stringContaining(`match the target 'missing'`));
-
-    warn.mockRestore();
   });
 
   it('Should replace', async () => {

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -1,4 +1,4 @@
-import { XmlFile } from '../src';
+import { Logger, XmlFile } from '../src';
 import { formatXml, serializeXml } from '../src/util/xml';
 import { VFS } from '../src/vfs';
 
@@ -172,6 +172,16 @@ describe('xml file', () => {
     `.trim());
   });
 
+  it('Should warn when a target matches no nodes', async () => {
+    const warn = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+
+    file.setAttrs('missing', { test: 'thing' });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`match the target 'missing'`));
+
+    warn.mockRestore();
+  });
+
   it('Should replace', async () => {
     file.replaceFragment('resources/string[@name="app_name"]', `
       <string name="app_name">$PRODUCT_NAME</string>
@@ -201,6 +211,53 @@ describe('xml file', () => {
       const node = file.find(target);
 
       expect(node).toBeDefined();
+    });
+
+    // https://github.com/ionic-team/trapeze/issues/190
+    describe('Should support documents with a default namespace #190', () => {
+      beforeEach(async () => {
+        vfs = new VFS();
+        file = new XmlFile('../common/test/fixtures/issues/190/config.xml', vfs);
+        await file.load();
+      });
+
+      it('Should find unprefixed targets', async () => {
+        expect(file.find('widget')).toHaveLength(1);
+        expect(file.find('//widget')).toHaveLength(1);
+        expect(file.find('/widget/allow-navigation')).toHaveLength(1);
+        expect(file.find(`//allow-navigation[@href='https://*/*']`)).toHaveLength(1);
+      });
+
+      it('Should find prefixed targets', async () => {
+        expect(file.find('/widget/cdv:plugin')).toHaveLength(1);
+      });
+
+      it('Should find targets using the local-name() workaround', async () => {
+        expect(file.find(`//*[local-name()='widget']`)).toHaveLength(1);
+      });
+
+      it('Should set attributes on an unprefixed target', async () => {
+        file.setAttrs('widget', { version: '7.8.9' });
+
+        const doc = file.getDocumentElement();
+        expect(doc?.getAttribute('version')).toBe('7.8.9');
+      });
+
+      it('Should inject into an unprefixed target', async () => {
+        file.injectFragment('widget', `<allow-navigation href="http://*/*" />`);
+
+        const serialized = await formatXml(file.getDocumentElement());
+        expect(serialized).toContain(`<allow-navigation href="http://*/*" />`);
+        // The injected node inherits the default namespace, so it is selectable too
+        expect(file.find('/widget/allow-navigation')).toHaveLength(2);
+      });
+
+      it('Should delete an unprefixed target', async () => {
+        file.deleteNodes('/widget/allow-navigation');
+
+        const serialized = await formatXml(file.getDocumentElement());
+        expect(serialized).not.toContain('allow-navigation');
+      });
     });
   });
 });


### PR DESCRIPTION
## Problem

XPath 1.0 resolves an unprefixed name test to the *no namespace* namespace. As soon as a document declares a default `xmlns` — a Cordova `config.xml` (`<widget xmlns="http://www.w3.org/ns/widgets">`), an `.xcworkspace/contents.xcworkspacedata`, and many others — targets such as `widget`, `//widget` or `/widget/allow-navigation` match **zero** nodes. Every XML operation (`attrs`, `inject`, `merge`, `replace`, `delete`) then silently does nothing and the file comes out unchanged, with no error and no warning.

The known workaround (`target: //*[local-name()='widget']`) works, but is unpleasant and undiscoverable.

## Fix

- `XmlFile` now evaluates targets through `xpath.parse(expr).select({ …, allowAnyNamespaceForNoPrefix: true })` instead of `xpath.useNamespaces()`, so an unprefixed name test also matches elements in the document's default namespace. Prefixed targets (`cdv:plugin`, `@android:name`), the `local-name()` workaround and namespace-less documents (`AndroidManifest.xml`, `strings.xml`) are unaffected.
- Mutating operations (`deleteNodes`, `deleteAttributes`, `injectFragment`, `mergeFragment`, `replaceFragment`, `setAttrs`) now emit a `Logger.warn` naming the file and target when the target resolves to zero nodes, so this class of problem is self-diagnosing rather than silent. Read-only `find()` stays quiet, since callers use it to probe for optional nodes.

Note: `xpath.parse(expr).select()` only supports node-set expressions (it throws for e.g. `count(...)`, which `useNamespaces` returned as a scalar). No caller uses such expressions.

## Verification

- New fixture `packages/common/test/fixtures/issues/190/config.xml` (minimal Cordova `config.xml` with a default namespace) plus tests in `packages/project/test/xml-file.test.ts` covering find/`setAttrs`/`injectFragment`/`deleteNodes` on unprefixed targets, prefixed targets, the `local-name()` workaround, and the new zero-match warning. Four of the new tests fail without the fix.
- `packages/project`: `npx vitest run` → **20 files, 131 tests passed** (Java 21 present, Gradle tests included).
- `packages/configure` (rebuilt `packages/project` first): `npx vitest run` → **23 files, 64 tests passed**.
- `npm run build` passes for `packages/project` and `packages/configure`. No zero-match warning fires anywhere in either suite.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)