### PR TITLE
fix(configure): working --help/--quiet, correct op labels, and surfaced pbxproj errors

### DIFF
--- a/packages/common/test/fixtures/project-only/capacitor.config.ts
+++ b/packages/common/test/fixtures/project-only/capacitor.config.ts
@@ -1,0 +1,10 @@
+const config = {
+  ios: {
+    path: 'ios/App',
+  },
+  android: {
+    path: 'android',
+  },
+};
+
+export default config;

--- a/packages/common/test/fixtures/project-only/project-json.json
+++ b/packages/common/test/fixtures/project-only/project-json.json
@@ -1,0 +1,9 @@
+{
+  "project_info": {
+    "project_id": "1234",
+    "project_number": "1234",
+    "name": "1234",
+    "firebase_url": ""
+  },
+  "client": []
+}

--- a/packages/common/test/fixtures/project-only/project-xml-strings.xml
+++ b/packages/common/test/fixtures/project-only/project-xml-strings.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="app_name">capacitor-configure-test</string>
+    <string name="title_activity_main">capacitor-configure-test</string>
+    <string name="package_name">io.ionic.starter</string>
+    <string name="custom_url_scheme">io.ionic.starter</string>
+</resources>

--- a/packages/configure/src/ctx.ts
+++ b/packages/configure/src/ctx.ts
@@ -41,7 +41,9 @@ export interface Variables {
 export async function loadContext(projectRootPath?: string, androidProject?: string, iosProject?: string): Promise<Context> {
   const rootDir = process.cwd();
 
-  const args = yargs(hideBin(process.argv));
+  // yargs only pre-parses the arguments needed to load the project. Its built-in
+  // --help/--version would print and exit before commander ever sees them.
+  const args = yargs(hideBin(process.argv)).help(false).version(false);
 
   const argv = args.argv as Args;
 

--- a/packages/configure/src/index.ts
+++ b/packages/configure/src/index.ts
@@ -3,6 +3,8 @@ import { Context, initLogging, loadContext, setArguments } from './ctx';
 import { fatal, logger } from './util/log';
 import { wrapAction } from './util/cli';
 
+const { version } = require('../package.json');
+
 export async function run() {
   try {
     initLogging(process.argv);
@@ -16,16 +18,19 @@ export async function run() {
 }
 
 export function runProgram(ctx: Context) {
-  // program.version(env.package.version);
   const program = new Command();
+
+  program.version(version);
 
   program
     .command('run [configFile]')
     .description(`Run project modification`)
     .option('--dry-run', 'Show changes before making them')
     .option('-y', 'Non-interactive')
+    .option('--no-commit', 'Show the changes but do not write them to disk')
     .option('--diff', 'Show a diff of each file')
     .option('--verbose', 'Verbose output')
+    .option('--quiet', 'Only print warnings and errors')
     .option('--android-project', 'Path to the root of the Android project (default: \'android\')')
     .option('--ios-project', 'Path to the root of the iOS project (default: \'ios/App\')')
     .option('--ios', 'Explicitly run iOS operations. This is exclusive, meaning other platforms not specified won\'t run when this flag is used')

--- a/packages/configure/src/index.ts
+++ b/packages/configure/src/index.ts
@@ -31,8 +31,8 @@ export function runProgram(ctx: Context) {
     .option('--diff', 'Show a diff of each file')
     .option('--verbose', 'Verbose output')
     .option('--quiet', 'Only print warnings and errors')
-    .option('--android-project', 'Path to the root of the Android project (default: \'android\')')
-    .option('--ios-project', 'Path to the root of the iOS project (default: \'ios/App\')')
+    .option('--android-project <path>', 'Path to the root of the Android project (default: \'android\')')
+    .option('--ios-project <path>', 'Path to the root of the iOS project (default: \'ios/App\')')
     .option('--ios', 'Explicitly run iOS operations. This is exclusive, meaning other platforms not specified won\'t run when this flag is used')
     .option('--android', 'Explicitly run Android operations. This is exclusive, meaning other platforms not specified won\'t run when this flag is used')
     .action(

--- a/packages/configure/src/tasks/run.ts
+++ b/packages/configure/src/tasks/run.ts
@@ -13,6 +13,8 @@ export async function runCommand(ctx: Context, configFile: YamlFile) {
   let processed: Operation[];
   let handlers: OperationHandlers = await loadHandlers();
 
+  printPlatformLoadErrors(ctx);
+
   try {
     const config = await loadYamlConfig(ctx, configFile);
 
@@ -34,13 +36,28 @@ export async function runCommand(ctx: Context, configFile: YamlFile) {
   }
 }
 
+// A platform project that fails to load stores the error instead of throwing, and every
+// operation on it then fails with a misleading message, so report the real cause up front.
+function printPlatformLoadErrors(ctx: Context) {
+  const iosError = ctx.project.ios?.getError();
+  if (iosError) {
+    logger.error(`Unable to load the iOS project: ${iosError.message}`);
+  }
+
+  const androidError = ctx.project.android?.getError();
+  if (androidError) {
+    logger.error(`Unable to load the Android project: ${androidError.message}`);
+  }
+}
+
 async function executeOperations(ctx: Context, handlers: OperationHandlers, operations: Operation[]) {
   for (const op of operations) {
+    const skipped = isOperationSkipped(ctx, op);
+
     if (!ctx.args.quiet) {
-      printOp(ctx, op);
+      printOp(op, skipped);
     }
 
-    const skipped = op.platform !== 'project' && (op.platform === 'ios' ? !ctx.project.ios : !ctx.project.android);
     if (skipped) {
       Logger.debug(`Skipping ${op.id} because ${op.platform} project does not exist`);
       continue;
@@ -58,8 +75,16 @@ async function executeOperations(ctx: Context, handlers: OperationHandlers, oper
   await checkModifiedFiles(ctx);
 }
 
-function printOp(ctx: Context, op: Operation) {
-  const skipped = op.platform === 'ios' ? !ctx.project.ios : !ctx.project.android;
+// Operations on the `project` platform always run, they don't target a native project
+function isOperationSkipped(ctx: Context, op: Operation) {
+  if (op.platform === 'project') {
+    return false;
+  }
+
+  return op.platform === 'ios' ? !ctx.project.ios : !ctx.project.android;
+}
+
+function printOp(op: Operation, skipped: boolean) {
   // const env = c.weak(`[${op.env}]`);
   const tag = skipped ? c.weak(c.strong(`skip`)) : kleur.bold().magenta(`run`);
   const platform = c.success(c.strong(`${op.platform}`));
@@ -86,14 +111,17 @@ async function checkModifiedFiles(ctx: Context) {
 
   Object.keys(files).map(k => {
     const file = files[k];
-    log(c.log.WARN(c.strong(`updated`)), file.getFilename());
+    if (!ctx.args.quiet) {
+      log(c.log.WARN(c.strong(`updated`)), file.getFilename());
+    }
     const diff = diffs.find((d: any) => d.file === file);
     if (diff && ctx.args.diff) {
       printDiff(diff);
     }
   });
 
-  if (ctx.args.noCommit) {
+  // commander sets `commit` to false when --no-commit is passed
+  if (ctx.args.commit === false) {
     return;
   }
 
@@ -115,7 +143,9 @@ async function checkModifiedFiles(ctx: Context) {
       log('Not applying changes. Exiting');
     }
   } else if (!ctx.args.dryRun && ctx.args.y) {
-    logger.info('-y provided, automatically applying configuration');
+    if (!ctx.args.quiet) {
+      logger.info('-y provided, automatically applying configuration');
+    }
     return ctx.project.vfs.commitAll(ctx.project);
   }
 }

--- a/packages/configure/test/tasks/run.test.ts
+++ b/packages/configure/test/tasks/run.test.ts
@@ -1,11 +1,27 @@
-import { copy, readFile, rm } from '@ionic/utils-fs';
+import { copy, readFile, rm, writeFile } from '@ionic/utils-fs';
 import { temporaryDirectory } from 'tempy';
 import { join } from 'path';
 import plist from 'plist';
 
 import { loadContext } from '../../src/ctx';
 import { runCommand } from '../../src/tasks/run';
+import { logger } from '../../src/util/log';
 import { loadYamlConfig } from '../../src/yaml-config';
+
+async function captureLoggedLines(run: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+    lines.push(args.join(' ').replace(/\x1b\[[0-9;]*m/g, ''));
+  });
+
+  try {
+    await run();
+  } finally {
+    spy.mockRestore();
+  }
+
+  return lines;
+}
 
 describe('task: run', () => {
   it('should process variables operations', async () => {
@@ -63,7 +79,7 @@ describe('task: run', () => {
 
     ctx.args.y = true;
     ctx.args.quiet = true;
-    ctx.args.noCommit = true;
+    ctx.args.commit = false;
 
     await runCommand(ctx, '../common/test/fixtures/basic.yml');
 
@@ -97,7 +113,7 @@ describe('task: run', () => {
     process.argv.push(dir);
     process.argv.push('-y');
     process.argv.push('--quiet');
-    process.argv.push('--noCommit');
+    process.argv.push('--no-commit');
     const ctx = await loadContext(undefined, 'my-android-app', 'my-ios-app/App');
     ctx.args.quiet = true;
 
@@ -136,7 +152,7 @@ describe('task: run', () => {
     const ctx = await loadContext(dir);
     ctx.args.y = true;
     ctx.args.quiet = true;
-    ctx.args.noCommit = true;
+    ctx.args.commit = false;
 
     await runCommand(ctx, join(dir, 'basic.yml'));
 
@@ -220,7 +236,7 @@ describe('task: run', () => {
     const ctx = await loadContext(dir);
     ctx.args.y = true;
     ctx.args.quiet = true;
-    ctx.args.noCommit = false;
+    ctx.args.commit = true;
 
     await runCommand(ctx, join(dir, 'basic.yml'));
 
@@ -315,6 +331,77 @@ describe('task: run', () => {
     expect(plistContents).toContain('msauth.com.microsoft.intunemam');
 
     // Cleanup temp dir
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should report project operations as run and not as skipped', async () => {
+    const dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/project-only', dir);
+
+    const ctx = await loadContext(dir);
+    ctx.args.commit = false;
+    ctx.args.quiet = false;
+
+    const lines = await captureLoggedLines(() =>
+      runCommand(ctx, '../common/test/fixtures/project.basic.yml'),
+    );
+
+    expect(lines).toContainEqual(expect.stringMatching(/^run project json/));
+    expect(lines).toContainEqual(expect.stringMatching(/^run project xml/));
+    expect(lines.some(line => line.startsWith('skip'))).toBe(false);
+    expect(lines.some(line => line.startsWith('updated'))).toBe(true);
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should not report operations or updated files when quiet', async () => {
+    const dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/project-only', dir);
+
+    const ctx = await loadContext(dir);
+    ctx.args.commit = false;
+    ctx.args.quiet = true;
+
+    const lines = await captureLoggedLines(() =>
+      runCommand(ctx, '../common/test/fixtures/project.basic.yml'),
+    );
+
+    expect(lines.some(line => line.startsWith('run'))).toBe(false);
+    expect(lines.some(line => line.startsWith('updated'))).toBe(false);
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should report why a native project failed to load', async () => {
+    const dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/ios-and-android', dir);
+    await writeFile(
+      join(dir, 'ios/App/App.xcodeproj/project.pbxproj'),
+      '// !$*UTF8*$!\n{ this is not a pbxproj }\n',
+    );
+
+    const ctx = await loadContext(dir);
+    ctx.args.commit = false;
+    ctx.args.quiet = true;
+
+    const errors: string[] = [];
+    const spy = vi
+      .spyOn(logger, 'error')
+      .mockImplementation((msg: any) => errors.push(String(msg)));
+
+    try {
+      await runCommand(ctx, '../common/test/fixtures/project.basic.yml');
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(errors).toContainEqual(
+      expect.stringContaining('Unable to load the iOS project'),
+    );
+
     await rm(dir, { force: true, recursive: true });
   });
 });

--- a/packages/project/src/util/pbx.ts
+++ b/packages/project/src/util/pbx.ts
@@ -10,14 +10,17 @@ export async function parsePbxProject(filename: string): Promise<any> {
   return proj.parseSync();
 }
 
+// Xcode leaves a value unquoted only when it consists solely of these characters,
+// see http://danwright.info/blog/2010/10/xcode-pbxproject-files/
+const PBX_UNQUOTED_VALUE = /^[A-Za-z0-9_$./]+$/;
+
 /**
- * PBX files are esoteric. Based on http://danwright.info/blog/2010/10/xcode-pbxproject-files/
- * we try to quote strings that need to be quoted. Right now
- * that test is just for a few characters but there may be
- * more that we need here
+ * PBX files are esoteric. Quote every value that Xcode itself would quote,
+ * otherwise the pbxproj we write can no longer be parsed (a `,` terminates a
+ * value, and non-ASCII characters are not valid in an unquoted value).
  */
 export function pbxSerializeString(value: string) {
-  if (/[\s;]/.test(value)) {
+  if (!PBX_UNQUOTED_VALUE.test(value)) {
     return `"${value}"`;
   }
   return value;

--- a/packages/project/src/util/pbx.ts
+++ b/packages/project/src/util/pbx.ts
@@ -18,19 +18,27 @@ const PBX_UNQUOTED_VALUE = /^[A-Za-z0-9_$./]+$/;
  * PBX files are esoteric. Quote every value that Xcode itself would quote,
  * otherwise the pbxproj we write can no longer be parsed (a `,` terminates a
  * value, and non-ASCII characters are not valid in an unquoted value).
+ * Inside a quoted value, a backslash and a double quote have to be escaped.
  */
 export function pbxSerializeString(value: string) {
   if (!PBX_UNQUOTED_VALUE.test(value)) {
-    return `"${value}"`;
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
   }
   return value;
 }
 
-// Remove any quotes at the beginning and end of the string value
+/**
+ * The pbx parser hands quoted values back verbatim, quotes and escapes
+ * included, so undo what `pbxSerializeString` wrote.
+ */
 export function pbxReadString(value: string) {
-  if (typeof value === 'string') {
-    return value?.replace(/(^")+|("$)+/g, '');
-  } else {
+  if (typeof value !== 'string') {
     return value;
   }
+
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\([\\"])/g, '$1');
+  }
+
+  return value;
 }

--- a/packages/project/test/project.ios.test.ts
+++ b/packages/project/test/project.ios.test.ts
@@ -167,6 +167,19 @@ describe('project - ios standard', () => {
     expect(reloaded.ios?.getBuildProperty('App', null, 'PRODUCT_NAME')).toBe('Acme,Inc');
   });
 
+  it('should write build settings containing quotes and backslashes that can be parsed again', async () => {
+    const productName = 'My "App" \\ Test';
+
+    project.ios?.setProductName('App', productName);
+    await project.commit();
+
+    const reloaded = new MobileProject(dir, { ios: { path: 'ios/App' } });
+    await reloaded.load();
+
+    expect(reloaded.ios?.getError()).toBe(null);
+    expect(reloaded.ios?.getBuildProperty('App', null, 'PRODUCT_NAME')).toBe(productName);
+  });
+
   it('should add frameworks', async () => {
     const fwks = ['ImageIO.framework', 'AudioToolbox.framework'];
     fwks.forEach(f => project.ios?.addFramework('App', f));

--- a/packages/project/test/project.ios.test.ts
+++ b/packages/project/test/project.ios.test.ts
@@ -156,6 +156,17 @@ describe('project - ios standard', () => {
     expect(actualValue).toBe('\"This Is A Long String\"');
   });
 
+  it('should write build settings that can be parsed again', async () => {
+    project.ios?.setProductName('App', 'Acme,Inc');
+    await project.commit();
+
+    const reloaded = new MobileProject(dir, { ios: { path: 'ios/App' } });
+    await reloaded.load();
+
+    expect(reloaded.ios?.getError()).toBe(null);
+    expect(reloaded.ios?.getBuildProperty('App', null, 'PRODUCT_NAME')).toBe('Acme,Inc');
+  });
+
   it('should add frameworks', async () => {
     const fwks = ['ImageIO.framework', 'AudioToolbox.framework'];
     fwks.forEach(f => project.ios?.addFramework('App', f));

--- a/packages/project/test/util/pbx.test.ts
+++ b/packages/project/test/util/pbx.test.ts
@@ -1,0 +1,18 @@
+import { pbxSerializeString } from '../../src/util/pbx';
+
+describe('pbx serialization', () => {
+  it('should leave values Xcode writes unquoted alone', () => {
+    expect(pbxSerializeString('App')).toBe('App');
+    expect(pbxSerializeString('io.ionic.starter')).toBe('io.ionic.starter');
+    expect(pbxSerializeString('App/Info.plist')).toBe('App/Info.plist');
+    expect(pbxSerializeString('1.4.5')).toBe('1.4.5');
+  });
+
+  it('should quote values that would otherwise break the pbxproj', () => {
+    expect(pbxSerializeString('My App')).toBe('"My App"');
+    expect(pbxSerializeString('Acme,Inc')).toBe('"Acme,Inc"');
+    expect(pbxSerializeString('Alkalmazás')).toBe('"Alkalmazás"');
+    expect(pbxSerializeString('App;')).toBe('"App;"');
+    expect(pbxSerializeString('')).toBe('""');
+  });
+});

--- a/packages/project/test/util/pbx.test.ts
+++ b/packages/project/test/util/pbx.test.ts
@@ -1,4 +1,4 @@
-import { pbxSerializeString } from '../../src/util/pbx';
+import { pbxReadString, pbxSerializeString } from '../../src/util/pbx';
 
 describe('pbx serialization', () => {
   it('should leave values Xcode writes unquoted alone', () => {
@@ -14,5 +14,25 @@ describe('pbx serialization', () => {
     expect(pbxSerializeString('Alkalmazás')).toBe('"Alkalmazás"');
     expect(pbxSerializeString('App;')).toBe('"App;"');
     expect(pbxSerializeString('')).toBe('""');
+  });
+
+  it('should escape backslashes and double quotes inside a quoted value', () => {
+    expect(pbxSerializeString('My "App"')).toBe('"My \\"App\\""');
+    expect(pbxSerializeString('back\\slash')).toBe('"back\\\\slash"');
+    expect(pbxSerializeString('escaped \\" already')).toBe('"escaped \\\\\\" already"');
+  });
+});
+
+describe('pbx reading', () => {
+  it('should leave unquoted values alone', () => {
+    expect(pbxReadString('App')).toBe('App');
+    expect(pbxReadString('io.ionic.starter')).toBe('io.ionic.starter');
+    expect(pbxReadString(undefined as any)).toBe(undefined);
+  });
+
+  it('should unquote and unescape what pbxSerializeString wrote', () => {
+    for (const value of ['My App', 'My "App"', 'back\\slash', 'escaped \\" already', '']) {
+      expect(pbxReadString(pbxSerializeString(value))).toBe(value);
+    }
   });
 });

--- a/packages/website/docs/ci-cd.md
+++ b/packages/website/docs/ci-cd.md
@@ -40,3 +40,5 @@ And here's how it works in Capawesome:
   },
 ```
 
+`-y` applies the changes without asking for confirmation, which is required on a build machine where nobody can answer the prompt. See [CLI options](./operations/getting-started#cli-options) for the full list of flags.
+

--- a/packages/website/docs/operations/getting-started.md
+++ b/packages/website/docs/operations/getting-started.md
@@ -38,6 +38,24 @@ platforms:
 
 Changes can be previewed using the `--diff` flag to see a unified diff of the changes to each file.
 
+## CLI options
+
+By default `run` lists the changed files and then asks for confirmation before writing them. The following options are available:
+
+| Option | Description |
+| --- | --- |
+| `-y` | Apply the changes without asking for confirmation. Use this in CI, where nobody can answer the prompt. |
+| `--dry-run` | Report the changes without writing them to disk. |
+| `--no-commit` | Report the changes without writing them to disk, same as `--dry-run`. |
+| `--diff` | Print a unified diff of the changes to each file. |
+| `--verbose` | Print debug output for every file that is read and modified. |
+| `--quiet` | Do not print the operations and the changed files. |
+| `--ios` | Only run iOS operations. Project-level operations still run. |
+| `--android` | Only run Android operations. Project-level operations still run. |
+| `--ios-project <path>` | Path to the root of the iOS Xcode project (default: `ios/App`). |
+| `--android-project <path>` | Path to the root of the Android project (default: `android`). |
+
+`npx trapeze --version` prints the installed version, and `npx trapeze run --help` prints this list for the version you have installed.
 
 ## Writing Configuration Files
 


### PR DESCRIPTION
## Problem

Four verified CLI/error-surfacing defects:

1. **#128** — `trapeze --help` / `run --help` printed yargs' generic help: the yargs parse inside `loadContext()` swallowed `--help`/`--version` before commander ever ran.
2. **#217 (cosmetic part)** — `printOp()` had no branch for `platform === 'project'`, so `project.*` operations printed as `skip` even when they ran — the likely source of the "doesn't work on web builds" confusion.
3. **#201 (CLI part)** — `--quiet` and `--noCommit` were read by `tasks/run.ts` but never registered as options, so both errored as unknown.
4. **#169** — pbxproj parse errors were stored in `getError()` and never printed, leaving only the misleading `Target 'App' not found in project`; and `pbxSerializeString` didn't quote commas/non-ASCII, so trapeze could corrupt the pbxproj it wrote ("works the first time, fails on the second run").

## Fix

- `packages/configure/src/ctx.ts` / `index.ts`: yargs parser gets `.help(false).version(false)`; commander's `program.version()` restored (reads the package version). `--quiet` and `--no-commit` (commander's idiomatic negation; `run.ts` now checks `args.commit === false`) are registered; `--quiet` gates the per-file `updated` lines and info output.
- `packages/configure/src/tasks/run.ts`: extracted `isOperationSkipped()` (returns `false` for `project` ops) used by both the skip logic and the label; `printPlatformLoadErrors()` prints stored iOS/Android load errors once at the start of the run.
- `packages/project/src/util/pbx.ts`: `pbxSerializeString` quotes anything not matching `^[A-Za-z0-9_$./]+$` (Xcode's own unquoted charset).
- Docs (#199): a "CLI options" table in `operations/getting-started.md` covering all registered flags, cross-linked from `ci-cd.md`.

## Verification

- Full suites pass: `packages/project` 127 tests (21 files), `packages/configure` 67 tests (23 files); root `npm run build` incl. the docs site validates the new anchors.
- Each new test verified to fail with its fix reverted: `pbxSerializeString` quoting + a `PRODUCT_NAME = Acme,Inc` set→commit→reload round-trip; the `project.*` op label (new `project-only` fixture — the bug is masked when native dirs exist); `--quiet` suppression; the surfaced iOS load error.
- Built-CLI outputs verified manually: `--help`, `run --help`, `--version` → `7.1.8`, `run -y` on a project-only fixture prints `run project ...` (was `skip`), `--quiet` produces no output while still writing, and a corrupted pbxproj now prints `[error] Unable to load the iOS project: Expected "/*" or "=" but "i" found.` before the run.

Note: `--noCommit` (camelCase, never a working flag) is replaced by `--no-commit`; 4 test-suite usages updated. `--dry-run` and `--no-commit` are behaviorally identical today and the docs say so.

Closes #128
Closes #199
Closes #169
Refs #217
Refs #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
