### PR TITLE
fix(project): only commit files that were actually modified

### DIFF
--- a/packages/configure/src/tasks/run.ts
+++ b/packages/configure/src/tasks/run.ts
@@ -107,6 +107,14 @@ async function printDiff(diff: VFSDiff) {
 
 async function checkModifiedFiles(ctx: Context) {
   const files = ctx.project.vfs.modifiedFiles();
+
+  if (!files.length) {
+    if (!ctx.args.quiet) {
+      logger.info('No changes to apply');
+    }
+    return;
+  }
+
   const diffs = ctx.args.diff ? await ctx.project.vfs.diffAll() : [];
 
   files.map(file => {

--- a/packages/configure/src/tasks/run.ts
+++ b/packages/configure/src/tasks/run.ts
@@ -106,11 +106,10 @@ async function printDiff(diff: VFSDiff) {
 }
 
 async function checkModifiedFiles(ctx: Context) {
-  const files = ctx.project.vfs.all();
+  const files = ctx.project.vfs.modifiedFiles();
   const diffs = ctx.args.diff ? await ctx.project.vfs.diffAll() : [];
 
-  Object.keys(files).map(k => {
-    const file = files[k];
+  files.map(file => {
     if (!ctx.args.quiet) {
       log(c.log.WARN(c.strong(`updated`)), file.getFilename());
     }

--- a/packages/configure/test/ops/android.gradle.test.ts
+++ b/packages/configure/test/ops/android.gradle.test.ts
@@ -1,4 +1,4 @@
-import { copy } from '@ionic/utils-fs';
+import { copy, readFile } from '@ionic/utils-fs';
 import { AndroidGradleInjectType } from '@trapezedev/project';
 import { GradleFile } from '@trapezedev/project/dist/android/gradle-file';
 import { join } from 'path';
@@ -282,5 +282,26 @@ task clean(type: Delete) {
 }
 `.trim()
     );
+  });
+
+  it('should write gradle to disk on commit', async () => {
+    const op: AndroidGradleOperation = makeOp('gradle', [
+      {
+        file: 'build.gradle',
+        target: {
+          dependencies: {}
+        },
+        insert: [{
+          implementation: "'test-implementation'"
+        }],
+        exact: true
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+    await ctx.project.commit();
+
+    const contents = await readFile(join(dir, 'android/build.gradle'), { encoding: 'utf-8' });
+    expect(contents).toContain("implementation 'test-implementation'");
   });
 });

--- a/packages/configure/test/ops/android.json.test.ts
+++ b/packages/configure/test/ops/android.json.test.ts
@@ -1,4 +1,4 @@
-import { copy } from '@ionic/utils-fs';
+import { copy, readFile } from '@ionic/utils-fs';
 import { JsonFile } from '@trapezedev/project';
 import { join } from 'path';
 import { temporaryDirectory } from 'tempy';
@@ -71,5 +71,26 @@ describe('op: android.json', () => {
         project_number: '1234',
       },
     });
+  });
+
+  it('should write json to disk on commit', async () => {
+    const op: AndroidJsonOperation = {
+      value: [
+        {
+          file: 'google-services.json',
+          set: {
+            project_info: {
+              project_id: 'my-id',
+            },
+          },
+        },
+      ],
+    };
+
+    await Op(ctx, op as Operation);
+    await ctx.project.commit();
+
+    const contents = await readFile(join(dir, 'android/google-services.json'), { encoding: 'utf-8' });
+    expect(contents).toContain('"project_id": "my-id"');
   });
 });

--- a/packages/configure/test/ops/ios.buildVersion.test.ts
+++ b/packages/configure/test/ops/ios.buildVersion.test.ts
@@ -40,4 +40,16 @@ describe('op: ios.buildVersion', () => {
 
     expect(ctx.project.ios?.getBuildProperty(null, null, 'CURRENT_PROJECT_VERSION')).toBe(1337);
   });
+
+  it('should write build settings to the pbxproj on commit', async () => {
+    const op: IosCopyOperation = makeOp('ios', 'buildNumber', 1337);
+
+    await Op(ctx, op as Operation);
+    await ctx.project.commit();
+
+    const pbxProj = await readFile(join(dir, 'ios/App/App.xcodeproj/project.pbxproj'), {
+      encoding: 'utf-8',
+    });
+    expect(pbxProj).toContain('CURRENT_PROJECT_VERSION = 1337');
+  });
 });

--- a/packages/configure/test/ops/ios.plist.test.ts
+++ b/packages/configure/test/ops/ios.plist.test.ts
@@ -1,4 +1,4 @@
-import { copy } from '@ionic/utils-fs';
+import { copy, readFile } from '@ionic/utils-fs';
 import { PlistFile } from '@trapezedev/project';
 import { join } from 'path';
 import { temporaryDirectory } from 'tempy';
@@ -130,5 +130,28 @@ describe('op: ios.plist', () => {
         "Bar": true
       }
     });
+  });
+
+  it('should write plist to disk on commit', async () => {
+    const op: IosPlistOperation = {
+      value: [
+        {
+          file: 'plist-file.plist',
+          replace: false,
+          entries: [{
+            TestKey: 'test-value'
+          }],
+        },
+      ],
+    };
+
+    await Op(ctx, op as Operation);
+    await ctx.project.commit();
+
+    const contents = await readFile(
+      join(ctx.project.config.ios?.path ?? '', 'plist-file.plist'),
+      { encoding: 'utf-8' },
+    );
+    expect(contents).toContain('<string>test-value</string>');
   });
 });

--- a/packages/configure/test/ops/ios.strings.test.ts
+++ b/packages/configure/test/ops/ios.strings.test.ts
@@ -1,4 +1,4 @@
-import { copy } from '@ionic/utils-fs';
+import { copy, readFile } from '@ionic/utils-fs';
 import { StringsFile } from '@trapezedev/project';
 import { join } from 'path';
 import { temporaryDirectory } from 'tempy';
@@ -95,5 +95,27 @@ describe('op: ios.strings', () => {
 
 "ErrorString_1" = "New4";
 `.trim());
+  });
+
+  it('should write strings to disk on commit', async () => {
+    const op: IosStringsOperation = {
+      value: [
+        {
+          file: 'App/Localizable.strings',
+          set: {
+            'Insert Element': 'Insert Element 2'
+          },
+        },
+      ],
+    };
+
+    await Op(ctx, op as Operation);
+    await ctx.project.commit();
+
+    const contents = await readFile(
+      join(ctx.project.config.ios?.path ?? '', 'App', 'Localizable.strings'),
+      { encoding: 'utf-8' },
+    );
+    expect(contents).toContain('"Insert Element" = "Insert Element 2";');
   });
 });

--- a/packages/configure/test/ops/ios.xcconfig.test.ts
+++ b/packages/configure/test/ops/ios.xcconfig.test.ts
@@ -1,4 +1,4 @@
-import { copy } from '@ionic/utils-fs';
+import { copy, readFile } from '@ionic/utils-fs';
 import { XCConfigFile } from '@trapezedev/project/src';
 import { join } from 'path';
 import { temporaryDirectory } from 'tempy';
@@ -42,5 +42,27 @@ describe('op: ios.strings', () => {
 PRODUCT_NAME = prod
 FOO[sdk=macosx*][arch=i386] = bar
 `.trim());
+  });
+
+  it('should write xcconfig to disk on commit', async () => {
+    const op: IosXCConfigOperation = {
+      value: [
+        {
+          file: 'App/Config.xcconfig',
+          set: {
+            'PRODUCT_NAME': 'prod',
+          },
+        },
+      ],
+    };
+
+    await Op(ctx, op as Operation);
+    await ctx.project.commit();
+
+    const contents = await readFile(
+      join(ctx.project.config.ios?.path ?? '', 'App', 'Config.xcconfig'),
+      { encoding: 'utf-8' },
+    );
+    expect(contents).toContain('PRODUCT_NAME = prod');
   });
 });

--- a/packages/configure/test/tasks/run.test.ts
+++ b/packages/configure/test/tasks/run.test.ts
@@ -1,4 +1,5 @@
 import { copy, readFile, rm, writeFile } from '@ionic/utils-fs';
+import { stat } from 'fs/promises';
 import { temporaryDirectory } from 'tempy';
 import { join } from 'path';
 import plist from 'plist';
@@ -404,4 +405,44 @@ describe('task: run', () => {
 
     await rm(dir, { force: true, recursive: true });
   });
+
+  it('should leave files alone that no operation modified', { timeout: 120000 }, async () => {
+    const dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/ios-and-android', dir);
+    await copy('../common/test/fixtures/project.basic.yml', join(dir, 'project.basic.yml'));
+
+    const manifest = join(dir, 'android/app/src/main/AndroidManifest.xml');
+    const pbxProj = join(dir, 'ios/App/App.xcodeproj/project.pbxproj');
+    const before = await readUntouched([manifest, pbxProj]);
+
+    const ctx = await loadContext(dir);
+    ctx.args.y = true;
+    ctx.args.quiet = true;
+
+    await runCommand(ctx, join(dir, 'project.basic.yml'));
+
+    // The platform files are opened on load but no operation touched them, so
+    // they must be neither rewritten nor re-touched
+    expect(await readUntouched([manifest, pbxProj])).toEqual(before);
+
+    expect(ctx.project.vfs.modifiedFiles().map(f => f.getFilename()).sort()).toEqual([
+      join(dir, 'project-json.json'),
+      join(dir, 'project-xml-strings.xml'),
+    ]);
+
+    const json = await readFile(join(dir, 'project-json.json'), { encoding: 'utf-8' });
+    expect(json).toContain('asdf');
+
+    await rm(dir, { force: true, recursive: true });
+  });
 });
+
+async function readUntouched(files: string[]) {
+  return Promise.all(
+    files.map(async file => ({
+      contents: await readFile(file, { encoding: 'utf-8' }),
+      modifiedAt: (await stat(file)).mtimeMs,
+    })),
+  );
+}

--- a/packages/configure/test/tasks/run.test.ts
+++ b/packages/configure/test/tasks/run.test.ts
@@ -425,6 +425,8 @@ describe('task: run', () => {
     const ctx = await loadContext(dir);
     ctx.args.y = true;
     ctx.args.quiet = true;
+    // An earlier test leaves --no-commit on process.argv; this test needs the commit
+    ctx.args.commit = true;
 
     await runCommand(ctx, join(dir, 'project.basic.yml'));
 

--- a/packages/configure/test/tasks/run.test.ts
+++ b/packages/configure/test/tasks/run.test.ts
@@ -7,7 +7,13 @@ import plist from 'plist';
 import { loadContext } from '../../src/ctx';
 import { runCommand } from '../../src/tasks/run';
 import { logger } from '../../src/util/log';
+import { logPrompt } from '../../src/util/cli';
 import { loadYamlConfig } from '../../src/yaml-config';
+
+vi.mock('../../src/util/cli', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../src/util/cli')>()),
+  logPrompt: vi.fn(),
+}));
 
 async function captureLoggedLines(run: () => Promise<void>): Promise<string[]> {
   const lines: string[] = [];
@@ -433,6 +439,28 @@ describe('task: run', () => {
 
     const json = await readFile(join(dir, 'project-json.json'), { encoding: 'utf-8' });
     expect(json).toContain('asdf');
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should not ask to apply changes when nothing was modified', async () => {
+    const dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/android-only', dir);
+    await copy('../common/test/fixtures/ios.notargets.nobuilds.yml', join(dir, 'ios.yml'));
+
+    const ctx = await loadContext(dir);
+    ctx.args.y = false;
+    ctx.args.quiet = true;
+    ctx.args.noCommit = false;
+
+    vi.mocked(logPrompt).mockClear();
+
+    // Every operation targets iOS, which this project does not have
+    await runCommand(ctx, join(dir, 'ios.yml'));
+
+    expect(ctx.project.vfs.modifiedFiles()).toEqual([]);
+    expect(logPrompt).not.toHaveBeenCalled();
 
     await rm(dir, { force: true, recursive: true });
   });

--- a/packages/project/src/android/gradle-file.ts
+++ b/packages/project/src/android/gradle-file.ts
@@ -36,6 +36,11 @@ export class GradleFile extends VFSStorable {
     return this.source;
   }
 
+  private setSource(source: string) {
+    this.source = source;
+    this.vfs.markModified(this.filename);
+  }
+
   /**
    * Replace the given properties at the specified point in the Gradle file or insert
    * if the replacement doesn't exist
@@ -209,7 +214,7 @@ export class GradleFile extends VFSStorable {
         .slice(Math.max(0, resolvedLastLine), sourceLines.length)
         .join('\n');
 
-    this.source = newSource;
+    this.setSource(newSource);
   }
 
   /**
@@ -428,7 +433,7 @@ export class GradleFile extends VFSStorable {
           .join('\n');
     }
 
-    this.source = newSource;
+    this.setSource(newSource);
   }
 
   find(pathObject: any | null, exact = false): { node: GradleASTNode; depth: number }[] {

--- a/packages/project/src/android/project.ts
+++ b/packages/project/src/android/project.ts
@@ -142,7 +142,7 @@ export class AndroidProject extends PlatformProject {
       }
     } else {
       Logger.v('android', 'setAppName', `No android:label on <application> node, setting value directly`);
-      application[0].setAttribute('android:label', appName);
+      this.manifest.setAttrs('manifest/application', { 'android:label': appName });
     }
   }
 

--- a/packages/project/src/ios/project.ts
+++ b/packages/project/src/ios/project.ts
@@ -37,9 +37,16 @@ const defaultInfoPlist = `<?xml version="1.0" encoding="UTF-8"?>
  */
 export class IosProject extends PlatformProject {
   private pbxProject: IosPbxProject | null = null;
+  private pbxFile: VFSRef<IosPbxProject> | null = null;
 
   constructor(project: MobileProject) {
     super(project);
+  }
+
+  // The pbx project is mutated in place, so every write has to flag its VFS
+  // entry as modified for it to be committed
+  private markPbxModified() {
+    this.pbxFile?.markModified();
   }
 
   private log(op: string, targetName: string | null, buildName: string | null | undefined, msg: string) {
@@ -150,6 +157,7 @@ export class IosProject extends PlatformProject {
     this.log('setBundleId', targetName, buildName, `to ${bundleId}`);
 
     this.pbxProject?.updateBuildProperty('PRODUCT_BUNDLE_IDENTIFIER', pbxSerializeString(bundleId), buildName, targetName);
+    this.markPbxModified();
   }
 
   /**
@@ -177,6 +185,7 @@ export class IosProject extends PlatformProject {
     this.log(`setProductName`, targetName, null, `PRODUCT_NAME to ${productName}`);
 
     this.pbxProject?.updateBuildProperty('PRODUCT_NAME', pbxSerializeString(productName), null, targetName);
+    this.markPbxModified();
   }
 
   /**
@@ -205,6 +214,7 @@ export class IosProject extends PlatformProject {
     }
 
     this.pbxProject?.updateBuildProperty('CURRENT_PROJECT_VERSION', buildNumber ?? 1, buildName, targetName);
+    this.markPbxModified();
 
     this.log(`setBuild`, targetName, buildName, `to ${buildNumber ?? 1}`);
 
@@ -270,6 +280,7 @@ export class IosProject extends PlatformProject {
         this.log(`incrementBuild`, targetName, buildName, `Setting initial value for CURRENT_PROJECT_VERSION to ensure incremented build number works`);
         // Set an initial value for CURRENT_PROJECT_VERSION
         this.pbxProject?.updateBuildProperty('CURRENT_PROJECT_VERSION', 1, buildName, targetName);
+        this.markPbxModified();
       } else {
         // There's already a CURRENT_PROJECT_VERSION set, which shouldn't happen, so do nothing
       }
@@ -283,6 +294,7 @@ export class IosProject extends PlatformProject {
     targetName = this.assertTargetName(targetName || null);
 
     this.pbxProject?.updateBuildProperty('MARKETING_VERSION', pbxSerializeString(version), buildName, targetName);
+    this.markPbxModified();
 
     this.log(`setVersion`, targetName, buildName, `to ${pbxSerializeString(version)}`);
 
@@ -319,6 +331,7 @@ export class IosProject extends PlatformProject {
     this.log(`setBuildProperty`, targetName, buildName, `Setting iOS build property ${key} = ${value}`);
 
     this.pbxProject?.updateBuildProperty(key, pbxSerializeString(value), buildName ? buildName : undefined /* must use undefined if null */, targetName);
+    this.markPbxModified();
   }
 
   /**
@@ -343,6 +356,7 @@ export class IosProject extends PlatformProject {
       target: target?.id,
       ...opts
     });
+    this.markPbxModified();
   }
 
   /**
@@ -555,6 +569,8 @@ export class IosProject extends PlatformProject {
     } else {
       this.pbxProject?.addSourceFile(path, {}, emptyGroup?.[0]);
     }
+
+    this.markPbxModified();
   }
 
   private async assertEntitlementsFile(targetName: IosTargetName, buildName: IosBuildName | null) {
@@ -685,7 +701,7 @@ export class IosProject extends PlatformProject {
       throw new Error('Unable to load pbxproj');
     }
     const pbxParsed = await parsePbxProject(filename);
-    this.project.vfs.open(filename, pbxParsed, this.pbxCommitFn);
+    this.pbxFile = this.project.vfs.open(filename, pbxParsed, this.pbxCommitFn);
     return pbxParsed;
   }
 

--- a/packages/project/src/json.ts
+++ b/packages/project/src/json.ts
@@ -69,6 +69,7 @@ export class JsonFile extends VFSStorable {
     });
 
     Object.assign(this.json, merged);
+    this.vfs.markModified(this.path);
   }
 
   async merge(properties: any): Promise<void> {
@@ -83,6 +84,7 @@ export class JsonFile extends VFSStorable {
     });
 
     Object.assign(this.json, merged);
+    this.vfs.markModified(this.path);
   }
 
   private commitFn = async (file: VFSFile) => {

--- a/packages/project/src/plist.ts
+++ b/packages/project/src/plist.ts
@@ -22,6 +22,7 @@ export class PlistFile extends VFSStorable {
 
   setDocument(doc: any) {
     this.doc = doc;
+    this.vfs.markModified(this.path);
   }
 
   async exists() {
@@ -82,7 +83,7 @@ export class PlistFile extends VFSStorable {
   async setFromXml(xml: string) {
     const parsed = parsePlistString(xml);
 
-    this.doc = parsed;
+    this.setDocument(parsed);
   }
 
   async set(properties: any): Promise<void> {
@@ -119,6 +120,7 @@ export class PlistFile extends VFSStorable {
     });
 
     Object.assign(this.doc, merged);
+    this.vfs.markModified(this.path);
   }
 
   async merge(properties: any): Promise<void> {
@@ -133,6 +135,7 @@ export class PlistFile extends VFSStorable {
     });
 
     Object.assign(this.doc, merged);
+    this.vfs.markModified(this.path);
   }
 
   /**

--- a/packages/project/src/properties.ts
+++ b/packages/project/src/properties.ts
@@ -50,6 +50,7 @@ export class PropertiesFile extends VFSStorable {
       }
     });
     Object.assign(this.doc, merged);
+    this.vfs.markModified(this.path);
   }
 
   async load() {

--- a/packages/project/src/strings.ts
+++ b/packages/project/src/strings.ts
@@ -67,6 +67,8 @@ export class StringsFile extends VFSStorable {
         });
       }
     });
+
+    this.vfs.markModified(this.path);
   }
 
   async load() {

--- a/packages/project/src/vfs.ts
+++ b/packages/project/src/vfs.ts
@@ -38,9 +38,15 @@ export class VFSRef<T extends VFSStorable> {
     return this.modified;
   }
 
+  // File wrappers that mutate their document in place must call this so the
+  // file is included when committing and diffing
+  markModified() {
+    this.modified = true;
+  }
+
   setData(data: T) {
     this.data = data;
-    this.modified = true;
+    this.markModified();
   }
 
   commit(): Promise<void> {
@@ -94,13 +100,17 @@ export class VFS {
     }, {} as { [key: string]: VFSFile });
   }
 
+  modifiedFiles(): VFSFile[] {
+    return Object.values(this.openFiles).filter(file => file.isModified());
+  }
+
   async commitAll(project: MobileProject) {
-    await Promise.all(Object.values(this.openFiles).map(file => file.commit()));
+    await Promise.all(this.modifiedFiles().map(file => file.commit()));
   }
 
   async diffAll() {
     const diffs = await Promise.all(
-      Object.values(this.openFiles).map(file => {
+      this.modifiedFiles().map(file => {
         if (file.diff) {
           return file.diff();
         }
@@ -115,6 +125,10 @@ export class VFS {
 
   set(filename: string, data: string | VFSStorable) {
     this.get(filename)?.setData(data);
+  }
+
+  markModified(filename: string) {
+    this.get(filename)?.markModified();
   }
 
   close(ref: VFSFile) {

--- a/packages/project/src/xcconfig.ts
+++ b/packages/project/src/xcconfig.ts
@@ -53,6 +53,8 @@ export class XCConfigFile extends VFSStorable {
     for (const key of newKeys) {
       this.doc += `\n${key} = ${values[key]}`;
     }
+
+    this.vfs.markModified(this.path);
   }
 
   async load() {

--- a/packages/project/src/xml.ts
+++ b/packages/project/src/xml.ts
@@ -184,6 +184,8 @@ export class XmlFile extends VFSStorable {
     for (const n of Array.prototype.slice.call(newTreeElement.documentElement.childNodes)) {
       node[0].appendChild(n);
     }
+
+    this.vfs.set(this.path, this);
   }
 
   mergeJsonTree(target: any, fragment: any) {

--- a/packages/project/test/project.android.test.ts
+++ b/packages/project/test/project.android.test.ts
@@ -307,6 +307,22 @@ try {
     expect(appName![0].textContent).toBe('Test Label');
   });
 
+  it('should set android app label on the manifest when there is no android:label', async () => {
+    const manifestPath = join(dir, 'android/app/src/main/AndroidManifest.xml');
+    const manifest = await readFile(manifestPath, { encoding: 'utf-8' });
+    await writeFile(manifestPath, manifest.replace('android:label="@string/app_name"', ''));
+
+    // The constructor resolves the platform paths in place, so a reload needs its own config
+    const projectWithoutLabel = new MobileProject(dir, { android: { path: 'android' } });
+    await projectWithoutLabel.load();
+
+    await projectWithoutLabel.android?.setAppName('Test Label');
+    await projectWithoutLabel.commit();
+
+    const written = await readFile(manifestPath, { encoding: 'utf-8' });
+    expect(written).toContain('android:label="Test Label"');
+  });
+
   it('should add resources file', async () => {
     await project.android?.addResource('raw', 'test.json', `{
       "thing": "cool"

--- a/packages/project/test/vfs.test.ts
+++ b/packages/project/test/vfs.test.ts
@@ -1,4 +1,5 @@
-import { VFS } from "../src/vfs";
+import { MobileProject } from "../src/project";
+import { VFS, VFSFile } from "../src/vfs";
 
 describe('vfs', () => {
   let vfs: VFS;
@@ -33,5 +34,25 @@ describe('vfs', () => {
       f2: vfs.get('f2'),
       f3: vfs.get('f3')
     });
+  });
+
+  it('should only commit modified files', async () => {
+    const committed: string[] = [];
+    const commitFn = async (file: VFSFile) => {
+      committed.push(file.getFilename());
+    };
+
+    vfs.open('f1', { thing: 'f1' }, commitFn);
+    vfs.open('f2', { thing: 'f2' }, commitFn);
+    vfs.open('f3', { thing: 'f3' }, commitFn);
+
+    vfs.markModified('f2');
+    vfs.set('f3', { thing: 'f3 updated' });
+
+    expect(vfs.modifiedFiles().map(f => f.getFilename())).toEqual(['f2', 'f3']);
+
+    await vfs.commitAll({} as MobileProject);
+
+    expect(committed).toEqual(['f2', 'f3']);
   });
 });


### PR DESCRIPTION
## Problem

`AndroidManifest.xml` and `project.pbxproj` are opened into the VFS whenever the
corresponding platform directory exists, regardless of what the config asks for.
`VFS.commitAll()` then wrote back **every** open file with no modification check —
`VFSRef.modified` / `isModified()` existed but were never read anywhere in the repo.

Running a `project.json`-only config against a project with `ios/` and `android/`
therefore:

- reformatted `AndroidManifest.xml` (one-time normalization churn: attributes collapsed
  onto one line, indentation rewritten),
- rewrote `project.pbxproj` byte-identically but bumped its mtime on **every** run,
- and listed both as `updated` in the CLI output.

## Fix

Filtering `commitAll()` on `isModified()` alone would have been a much worse bug: only
`XmlFile` (and a few `IosProject` plist writes) called `vfs.set()`. `PlistFile`,
`JsonFile`, `PropertiesFile`, `StringsFile`, `XCConfigFile`, `GradleFile` and the pbxproj
all mutate their in-memory document in place and never flagged the ref — filtering first
would have silently stopped committing gradle/properties/strings/xcconfig edits.

So, in order:

1. **Every file wrapper now flags its VFS ref on mutation.** Added `VFSRef.markModified()`
   / `VFS.markModified(filename)` and called it from every mutating path:
   - `PlistFile.setDocument/setFromXml/set/merge` (`update` goes through `setDocument`)
   - `JsonFile.set/merge`
   - `PropertiesFile.updateProperties`
   - `StringsFile.set`
   - `XCConfigFile.set`
   - `GradleFile` — all three `this.source = …` sinks now go through a private `setSource()`
   - `XmlFile.mergeFragment` — the one `XmlFile` mutator that was missing the flag
   - `IosProject` — a private `markPbxModified()` on every method that writes build
     settings or pbxproj state (`setBundleId`, `setProductName`, `setBuild`,
     `incrementBuild`, `setVersion`, `setBuildProperty`, `addFramework`, `addFile`)
   - `AndroidProject.setAppName` poked the manifest DOM directly, bypassing `XmlFile`;
     it now goes through `XmlFile.setAttrs`
2. **Then** `VFS.commitAll()`, `VFS.diffAll()` and `checkModifiedFiles()` in the CLI filter
   on the new `VFS.modifiedFiles()`, so untouched files are neither listed as `updated`
   nor rewritten.

## Verified locally

- `packages/project`: **126 tests / 20 files passed** (Java 21 present, gradle tests real)
- `packages/configure`: **71 tests / 23 files passed**
- New tests:
  - `run.test.ts` — the #110 repro: a `project`-only config against the `ios-and-android`
    fixture leaves `AndroidManifest.xml` and `project.pbxproj` byte-identical **and**
    un-touched (mtime), and `vfs.modifiedFiles()` contains only the two project files.
    Confirmed it fails without the fix, with exactly the reported reformatting diff.
  - A "writes to disk on commit" guard for **each** file type — json, plist, strings,
    xcconfig, gradle, pbxproj build settings (properties and xml already had one).
    Confirmed all seven fail when `markModified()` is stubbed out, i.e. they really do
    guard against the trap above.
  - `vfs.test.ts` — `commitAll()` commits only modified refs.
  - `project.android.test.ts` — `setAppName` writes the manifest when there is no
    `android:label` (the direct-DOM path). Confirmed it fails if that path is reverted.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
