### PR TITLE
fix(project): revert prettier 3 upgrade to prevent XML entity corruption

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,25 +22,22 @@ jobs:
     if: github.repository == 'ionic-team/trapeze'
     runs-on: ubuntu-latest
     steps:
+      # Verified before release-please cuts any tag, so a broken commit fails here
+      # instead of leaving a tagged release that never reaches npm
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci
+      # Scoped to the published packages; the private website is covered by CI
+      - run: npm run build -- --filter='@trapezedev/*'
+      - run: npm test -- --filter='@trapezedev/*'
       - name: Create release pull request or GitHub release
         id: release-please
         uses: googleapis/release-please-action@v4
-      - uses: actions/checkout@v4
-        if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-      - uses: actions/setup-node@v4
-        if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-        with:
-          node-version: ${{ env.NODE_VERSION }}
       - name: Update npm for OIDC trusted publishing
         if: ${{ steps.release-please.outputs.releases_created == 'true' }}
         run: npm install -g npm@latest
-      - if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-        run: npm ci
-      # Scoped to the published packages; the private website is covered by CI
-      - if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-        run: npm run build -- --filter='@trapezedev/*'
-      - if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-        run: npm test -- --filter='@trapezedev/*'
       # Published in dependency order: gradle-parse <- project <- configure
       - name: Publish @trapezedev/gradle-parse
         if: ${{ steps.release-please.outputs['packages/gradle-parse--release_created'] == 'true' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6053,6 +6053,16 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "license": "MIT"
     },
+    "node_modules/@prettier/plugin-xml": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
+      "integrity": "sha512-UWRmygBsyj4bVXvDiqSccwT1kmsorcwQwaIy30yVh8T+Gspx4OlC0shX1y+ZuwXZvgnafmpRYKks0bAu9urJew==",
+      "license": "MIT",
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11",
+        "prettier": ">=2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
@@ -7013,6 +7023,13 @@
         "@types/node": "*",
         "xmlbuilder": ">=11.0.1"
       }
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/prismjs": {
       "version": "1.26.6",
@@ -21988,7 +22005,7 @@
       "dependencies": {
         "@ionic/utils-fs": "^3.1.5",
         "@ionic/utils-subprocess": "^2.1.8",
-        "@prettier/plugin-xml": "^3.4.2",
+        "@prettier/plugin-xml": "^2.2.0",
         "@trapezedev/gradle-parse": "7.1.8",
         "@xmldom/xmldom": "^0.9.9",
         "cross-spawn": "^7.0.3",
@@ -21998,7 +22015,7 @@
         "kleur": "^4.1.5",
         "lodash": "^4.17.21",
         "plist": "^3.0.4",
-        "prettier": "^3.9.6",
+        "prettier": "^2.7.1",
         "xcode": "^3.0.1",
         "xml-js": "^1.6.11",
         "xpath": "^0.0.32"
@@ -22009,6 +22026,7 @@
         "@types/ini": "^1.3.31",
         "@types/lodash": "^4.14.175",
         "@types/plist": "^3.0.2",
+        "@types/prettier": "^2.7.3",
         "rimraf": "^6.0.1",
         "tempy": "^3.1.0",
         "typescript": "^5.9.3",
@@ -22016,18 +22034,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "packages/project/node_modules/@prettier/plugin-xml": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.2.tgz",
-      "integrity": "sha512-/UyNlHfkuLXG6Ed85KB0WBF283xn2yavR+UtRibBRUcvEJId2DSLdGXwJ/cDa1X++SWDPzq3+GSFniHjkNy7yg==",
-      "license": "MIT",
-      "dependencies": {
-        "@xml-tools/parser": "^1.0.11"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0"
       }
     },
     "packages/project/node_modules/picomatch": {
@@ -22041,21 +22047,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "packages/project/node_modules/prettier": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
-      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/project/node_modules/std-env": {

--- a/packages/common/test/fixtures/xml-entities.xml
+++ b/packages/common/test/fixtures/xml-entities.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="deep_link">https://example.com/?a=1&amp;b=2</string>
+    <string name="company">Smith &amp; Sons</string>
+    <string name="comparison">a &lt; b &gt; c</string>
+</resources>

--- a/packages/configure/test/ops/android.manifest.test.ts
+++ b/packages/configure/test/ops/android.manifest.test.ts
@@ -110,7 +110,8 @@ describe('op: android.manifest', () => {
             android:name="androidx.core.content.FileProvider"
             android:authorities="\${applicationId}.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true" />
+            android:grantUriPermissions="true"
+        />
     </application>
 </manifest>
     `.trim());

--- a/packages/configure/test/ops/android.xml.test.ts
+++ b/packages/configure/test/ops/android.xml.test.ts
@@ -132,7 +132,8 @@ describe('op: android.xml', () => {
             android:name="io.ionic.starter.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
-            android:launchMode="singleTask" />
+            android:launchMode="singleTask"
+        />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/packages/configure/test/ops/project.xml.test.ts
+++ b/packages/configure/test/ops/project.xml.test.ts
@@ -104,7 +104,8 @@ describe('op: project.xml', () => {
             android:name="io.ionic.starter.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
-            android:launchMode="singleTask" />
+            android:launchMode="singleTask"
+        />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@ionic/utils-fs": "^3.1.5",
     "@ionic/utils-subprocess": "^2.1.8",
-    "@prettier/plugin-xml": "^3.4.2",
+    "@prettier/plugin-xml": "^2.2.0",
     "@trapezedev/gradle-parse": "7.1.8",
     "@xmldom/xmldom": "^0.9.9",
     "cross-spawn": "^7.0.3",
@@ -32,7 +32,7 @@
     "kleur": "^4.1.5",
     "lodash": "^4.17.21",
     "plist": "^3.0.4",
-    "prettier": "^3.9.6",
+    "prettier": "^2.7.1",
     "xcode": "^3.0.1",
     "xml-js": "^1.6.11",
     "xpath": "^0.0.32"
@@ -51,6 +51,7 @@
     "@types/ini": "^1.3.31",
     "@types/lodash": "^4.14.175",
     "@types/plist": "^3.0.2",
+    "@types/prettier": "^2.7.3",
     "rimraf": "^6.0.1",
     "tempy": "^3.1.0",
     "typescript": "^5.9.3",

--- a/packages/project/src/declarations.d.ts
+++ b/packages/project/src/declarations.d.ts
@@ -7,3 +7,6 @@ declare module 'gradle-to-js/lib/parser.js' {
   var x: any;
   export = x;
 }
+
+declare module "@prettier/plugin-xml" {
+}

--- a/packages/project/src/util/xml.ts
+++ b/packages/project/src/util/xml.ts
@@ -1,8 +1,10 @@
 /// <reference lib="dom" />
 
+import { dirname } from 'path';
 import { readFile, writeFile } from '@ionic/utils-fs';
 import xmldom, { XMLSerializer } from '@xmldom/xmldom';
 import prettier from 'prettier';
+import prettierXml from '@prettier/plugin-xml';
 
 export async function parseXml(filename: string): Promise<Document> {
   let contents = await readFile(filename, { encoding: 'utf-8' });
@@ -35,14 +37,16 @@ export function serializeXml(doc: any) {
 export async function formatXml(doc: any) {
   const xml = new XMLSerializer().serializeToString(doc);
 
+  const pluginDir = dirname(require.resolve('@prettier/plugin-xml'));
+
   return prettier.format(xml, {
     parser: 'xml',
     printWidth: 120,
     bracketSameLine: true,
     xmlWhitespaceSensitivity: 'ignore',
     tabWidth: 4,
-    // The plugin is ESM-only, so it is passed by path and loaded by prettier instead of imported
-    plugins: [require.resolve('@prettier/plugin-xml')]
+    pluginSearchDirs: [pluginDir],
+    plugins: [prettierXml]
   } as any);
 }
 

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -1,3 +1,7 @@
+import { join } from 'path';
+import { copy, readFile, rm } from '@ionic/utils-fs';
+import { temporaryDirectory } from 'tempy';
+
 import { Logger, XmlFile } from '../src';
 import { formatXml, serializeXml } from '../src/util/xml';
 import { VFS } from '../src/vfs';
@@ -196,6 +200,38 @@ describe('xml file', () => {
     <string name="package_name">io.ionic.starter</string>
     <string name="custom_url_scheme">io.ionic.starter</string>
 </resources>`.trim());
+  });
+
+  // The XML formatter must never re-space text nodes: doing so silently rewrites values
+  // such as URLs with query parameters in every XML file Trapeze commits
+  describe('Entities in element text', () => {
+    let dir: string;
+    let path: string;
+
+    beforeEach(async () => {
+      dir = temporaryDirectory();
+      path = join(dir, 'strings.xml');
+      await copy('../common/test/fixtures/xml-entities.xml', path);
+
+      vfs = new VFS();
+      file = new XmlFile(path, vfs);
+      await file.load();
+    });
+
+    afterEach(async () => {
+      await rm(dir, { force: true, recursive: true });
+    });
+
+    it('Should survive an unrelated change and a commit unmodified', async () => {
+      file.setAttrs('/resources', { 'xmlns:tools': 'http://schemas.android.com/tools' });
+
+      await vfs.get(path)?.commit();
+
+      const committed = await readFile(path, { encoding: 'utf-8' });
+      expect(committed).toContain(`<string name="deep_link">https://example.com/?a=1&amp;b=2</string>`);
+      expect(committed).toContain(`<string name="company">Smith &amp; Sons</string>`);
+      expect(committed).toContain(`<string name="comparison">a &lt; b &gt; c</string>`);
+    });
   });
 
   describe('GitHub Issue Tests', () => {

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -225,7 +225,9 @@ describe('xml file', () => {
     it('Should survive an unrelated change and a commit unmodified', async () => {
       file.setAttrs('/resources', { 'xmlns:tools': 'http://schemas.android.com/tools' });
 
-      await vfs.get(path)?.commit();
+      const ref = vfs.get(path);
+      expect(ref).toBeDefined();
+      await ref!.commit();
 
       const committed = await readFile(path, { encoding: 'utf-8' });
       expect(committed).toContain(`<string name="deep_link">https://example.com/?a=1&amp;b=2</string>`);

--- a/packages/project/tsconfig.json
+++ b/packages/project/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "target": "es2019",
-    "types": ["node", "cross-spawn", "diff", "ini", "lodash", "plist"]
+    "types": ["node", "cross-spawn", "diff", "ini", "lodash", "plist", "prettier"]
   },
   "files": ["src/index.ts"],
   "include": ["/src/**/*.ts", "**/src/**/*.ts", "/src/**/*.d.ts"]


### PR DESCRIPTION
## 1. Revert the prettier 3 upgrade — XML entity corruption

`@prettier/plugin-xml` 3 does not just reformat XML, it **rewrites values**. Any element text
node containing a character reference (`&amp;`, `&lt;`, `&gt;`, `&#38;`, …) is broken onto its
own line **and gets spaces inserted around the entity**:

```xml
<!-- input -->
<string name="deep_link">https://example.com/?a=1&amp;b=2</string>

<!-- committed by main (plugin-xml 3) -->
<string name="deep_link">
    https://example.com/?a=1 &amp; b=2
</string>
```

The deep link value silently changes from `https://example.com/?a=1&b=2` to
`https://example.com/?a=1 & b=2`. `formatXml()` is the shared write path behind
`XmlFile.xmlCommitFn`, so this affects **every XML file Trapeze commits** — `AndroidManifest.xml`,
`res/values/*.xml`, Cordova `config.xml`, and anything touched via the `xml` / `manifest` ops.
The mangling happens even when the operation that triggered the commit is completely unrelated
(e.g. a plain `appName` change). Attributes are unaffected; only text nodes are.

This PR restores the pre-#246 XML formatting stack in `@trapezedev/project`:

- `prettier` `^3.9.6` → `^2.7.1`, `@prettier/plugin-xml` `^3.4.2` → `^2.2.0`
- `@types/prettier` back as a devDependency, `"prettier"` back in the tsconfig `types`
- the static plugin import + `pluginSearchDirs` in `src/util/xml.ts`, and the
  `declare module "@prettier/plugin-xml"` stub
- the three XML expectations #246 changed for plugin 3's self-closing-tag placement

The `engines` field and the unused-dependency removals from #246 are **kept** — only the
prettier/plugin-xml pieces are reverted.

**This deliberately reopens the nested prettier 2 duplication reported in #227.** A correct v3
upgrade is not a version bump: `xmlWhitespaceSensitivity: 'ignore'` is what triggers the
re-spacing, and `'strict'` (which fixes text nodes) also changes element indentation across the
board. That needs its own PR with the output diff reviewed deliberately, so shipping correct
files takes priority over the dependency-tree cleanup here.

## 2. Regression test

New fixture `packages/common/test/fixtures/xml-entities.xml` with entities in element text, plus
a test in `packages/project/test/xml-file.test.ts` that copies it to a temp dir, applies an
**unrelated** mutation (adds a namespace attribute on the root), commits through the VFS, and
asserts the three entity-bearing values survive byte-exact.

The repo had **zero** XML-entity coverage before this
(`grep -rn "&amp;\|&lt;\|&gt;" packages/common/test/fixtures --include='*.xml'` → no hits), which
is why #246 shipped green.

## 3. `release.yml`: build and test before release-please

The release job ran `release-please-action` **first** — creating the git tags and the GitHub
Release — and only then checked out, built and tested. A failing suite therefore left a tagged,
released version that never reached npm and required manual cleanup. That is exactly how 7.1.6
ended up half-released.

Checkout / `npm ci` / build / test now run unconditionally at the top of the job, and
release-please plus the three `npm publish` steps only run after they pass. The build and test
steps keep their `--filter='@trapezedev/*'` scoping, the publish steps keep their per-package
`release_created` conditions, and OIDC permissions are unchanged. As a side benefit the release
commit is now built and tested before its tags exist.

## Verification

Local, on this branch (`npm ci` → `npm run build` → per-package `vitest run`):

| suite | result |
|---|---|
| `packages/project` | **160 passed** (21 files) — 159 on `main` + the new regression test |
| `packages/configure` | **82 passed** (23 files) |
| root `npm run build` | 3/3 tasks successful |

The new test was verified to **fail before the revert** — on `main` with plugin-xml 3 it reported:

```
- <string name="deep_link">https://example.com/?a=1&amp;b=2</string>
+     <string name="deep_link">
+         https://example.com/?a=1 &amp; b=2
+     </string>
```

and passes after it.

`.github/workflows/release.yml` was parsed to confirm the resulting step order:
checkout → setup-node → `npm ci` → build → test → release-please → npm upgrade → 3× publish.

Refs #227
Refs #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
