### PR TITLE
test: cover the commit/prompt flow, untested operations, and framework detection

### DIFF
--- a/packages/configure/src/op.ts
+++ b/packages/configure/src/op.ts
@@ -198,8 +198,12 @@ function createOpDisplayText(op: Partial<Operation>) {
       return (Array.isArray(op.value) ? op.value : op.value.entries).map((v: any) => Object.keys(v)).join(', ');
     case 'ios.frameworks':
       return op.value.join(', ');
-    case 'ios.plist':
-      return `${op.value.entries.length} modifications`;
+    case 'ios.plist': {
+      // The documented form is a list of entry groups, the legacy form a single one
+      const groups = Array.isArray(op.value) ? op.value : [op.value];
+      const entries = groups.flatMap((group: any) => group.entries ?? []);
+      return `${entries.length} ${pluralize(entries.length, 'modification')}`;
+    }
     case 'ios.xml':
       return `${op.value.length} ${pluralize(op.value.length, 'modification')}`;
     case 'ios.json':

--- a/packages/configure/test/op.test.ts
+++ b/packages/configure/test/op.test.ts
@@ -49,16 +49,57 @@ describe('operation processing', () => {
     });
   });
 
+  describe('Display text', () => {
+    it('should count every plist entry, not the list of entry groups', async () => {
+      const processed = processOperations({
+        platforms: {
+          ios: {
+            targets: {
+              App: {
+                plist: [
+                  { replace: true, entries: [{ UIRequiresFullScreen: true }] },
+                  { entries: [{ NSFaceIDUsageDescription: 'Log in' }] },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      expect(processed[0].displayText).toBe('2 modifications');
+    });
+
+    it('should count the plist entries of the legacy object form', async () => {
+      const processed = processOperations({
+        platforms: {
+          ios: {
+            targets: {
+              App: {
+                plist: { entries: [{ UIRequiresFullScreen: true }] },
+              },
+            },
+          },
+        },
+      });
+
+      expect(processed[0].displayText).toBe('1 modification');
+    });
+  });
+
   describe('Project', () => {
     it('should process project operations', async () => {
-      const makeOp = (name: string, value: any): Operation => ({
+      const makeOp = (
+        name: string,
+        value: any,
+        displayText: any = expect.anything(),
+      ): Operation => ({
         id: `project.${name}`,
         platform: 'project',
         name,
         value,
         iosTarget: null,
         iosBuild: null,
-        displayText: expect.anything(),
+        displayText,
       });
       const parsed = await loadYamlConfig(
         ctx,
@@ -72,7 +113,7 @@ describe('operation processing', () => {
           file: 'project-xml-strings.xml',
           target: 'resources/string[@name="app_name"]',
           replace: '<string name="app_name">Awesome App</string>\n'
-        }]),
+        }], '1 modification'),
         makeOp('json', [{
           file: 'project-json.json',
           set: {
@@ -80,21 +121,25 @@ describe('operation processing', () => {
               project_id: 'asdf'
             }
           }
-        }])
+        }], '1 modification')
       ] as Operation[]);
     });
   });
 
   describe('Android', () => {
     it('should process android operations', async () => {
-      const makeOp = (name: string, value: any): Operation => ({
+      const makeOp = (
+        name: string,
+        value: any,
+        displayText: any = expect.anything(),
+      ): Operation => ({
         id: `android.${name}`,
         platform: 'android',
         name,
         value,
         iosTarget: null,
         iosBuild: null,
-        displayText: expect.anything(),
+        displayText,
       });
       const parsed = await loadYamlConfig(
         ctx,
@@ -104,8 +149,12 @@ describe('operation processing', () => {
       const processed = processOperations(parsed);
 
       expect(processed).toMatchObject([
-        makeOp('packageName', 'com.ionicframework.awesomePackage'),
-        makeOp('versionName', '1.2.3'),
+        makeOp(
+          'packageName',
+          'com.ionicframework.awesomePackage',
+          'com.ionicframework.awesomePackage',
+        ),
+        makeOp('versionName', '1.2.3', '1.2.3'),
         makeOp('incrementVersionCode', true),
       ] as Operation[]);
     });
@@ -113,14 +162,18 @@ describe('operation processing', () => {
 
   describe('iOS', () => {
     it('should process ios operations with targets and build', async () => {
-      const makeOp = (name: string, value: any): Operation => ({
+      const makeOp = (
+        name: string,
+        value: any,
+        displayText: any = expect.anything(),
+      ): Operation => ({
         id: `ios.${name}`,
         platform: 'ios',
         name,
         iosTarget: 'App',
         iosBuild: 'Debug',
         value,
-        displayText: expect.anything(),
+        displayText,
       });
       const parsed = await loadYamlConfig(
         ctx,
@@ -130,11 +183,11 @@ describe('operation processing', () => {
       const processed = processOperations(parsed);
 
       expect(processed).toMatchObject([
-        makeOp('bundleId', 'com.ionicframework.testBundle'),
+        makeOp('bundleId', 'com.ionicframework.testBundle', 'com.ionicframework.testBundle'),
         makeOp('version', 16.4),
         makeOp('incrementBuild', true),
-        makeOp('productName', 'Awesome App'),
-        makeOp('displayName', 'My Awesome App'),
+        makeOp('productName', 'Awesome App', 'Awesome App'),
+        makeOp('displayName', 'My Awesome App', 'My Awesome App'),
       ] as Operation[]);
     });
 

--- a/packages/configure/test/ops/android.packageName.test.ts
+++ b/packages/configure/test/ops/android.packageName.test.ts
@@ -1,4 +1,4 @@
-import { copy, pathExists, rm } from '@ionic/utils-fs';
+import { copy, pathExists, readFile, rm } from '@ionic/utils-fs';
 import { join } from 'path';
 import { temporaryDirectory } from 'tempy';
 
@@ -28,11 +28,33 @@ describe('op: android.packageName', () => {
     await rm(dir, { force: true, recursive: true });
   });
 
+  it('should set the package name', async () => {
+    await Op(ctx, op);
+
+    expect(await ctx.project.android?.getPackageName()).toBe('io.ionic.renamed');
+  });
+
   it('should move the source tree to the new package', async () => {
     await Op(ctx, op);
 
     expect(await pathExists(join(dir, 'android/app/src/main/java/io/ionic/renamed'))).toBe(true);
     expect(await pathExists(join(dir, 'android/app/src/main/java/io/ionic/starter'))).toBe(false);
+  });
+
+  it('should rewrite the sources and manifest on commit', async () => {
+    await Op(ctx, op);
+    await ctx.project.commit();
+
+    const sourceDir = join(dir, 'android/app/src/main/java');
+    const activity = await readFile(join(sourceDir, 'io/ionic/renamed/MainActivity.java'), {
+      encoding: 'utf-8',
+    });
+    expect(activity).toContain('package io.ionic.renamed;');
+
+    const manifest = await readFile(join(dir, 'android/app/src/main/AndroidManifest.xml'), {
+      encoding: 'utf-8',
+    });
+    expect(manifest).toContain('package="io.ionic.renamed"');
   });
 
   it('should not move source files on a dry run', async () => {

--- a/packages/configure/test/ops/android.res.test.ts
+++ b/packages/configure/test/ops/android.res.test.ts
@@ -83,16 +83,17 @@ describe('op: android.res', () => {
   it('should not add a resource file on a dry run', async () => {
     ctx.args.dryRun = true;
 
+    // dry_run_config.json must not exist in the fixture, or this assertion is vacuous
     const op = makeOp('android', 'res', [
       {
         path: 'raw',
-        file: 'auth_config.json',
+        file: 'dry_run_config.json',
         text: '{ "client_id": "abc123" }',
       },
     ]);
 
     await Op(ctx, op as Operation);
 
-    expect(await pathExists(join(dir, 'android/app/src/main/res/raw/auth_config.json'))).toBe(false);
+    expect(await pathExists(join(dir, 'android/app/src/main/res/raw/dry_run_config.json'))).toBe(false);
   });
 });

--- a/packages/configure/test/ops/android.res.test.ts
+++ b/packages/configure/test/ops/android.res.test.ts
@@ -11,8 +11,6 @@ import { makeOp } from '../utils';
 describe('op: android.res', () => {
   let dir: string;
   let ctx: Context;
-  let resFile: string;
-  let op: Operation;
 
   beforeEach(async () => {
     dir = temporaryDirectory();
@@ -21,32 +19,80 @@ describe('op: android.res', () => {
 
     ctx = await loadContext(dir);
     ctx.args.quiet = true;
-
-    resFile = join(dir, 'android/app/src/main/res/raw/test_config.json');
-    op = makeOp('android', 'res', [
-      {
-        path: 'raw',
-        file: 'test_config.json',
-        text: '{ "client_id": "test" }',
-      },
-    ]);
   });
 
   afterEach(async () => {
     await rm(dir, { force: true, recursive: true });
   });
 
-  it('should add a resource file', async () => {
-    await Op(ctx, op);
+  it('should write a resource file from text', async () => {
+    const op = makeOp('android', 'res', [
+      {
+        path: 'raw',
+        file: 'auth_config.json',
+        text: '{ "client_id": "abc123" }',
+      },
+    ]);
 
-    expect(await readFile(resFile, { encoding: 'utf-8' })).toBe('{ "client_id": "test" }');
+    await Op(ctx, op as Operation);
+
+    const file = await readFile(join(dir, 'android/app/src/main/res/raw/auth_config.json'), {
+      encoding: 'utf-8',
+    });
+    expect(file).toBe('{ "client_id": "abc123" }');
+  });
+
+  it('should copy a resource file from a source file', async () => {
+    const op = makeOp('android', 'res', [
+      {
+        path: 'drawable',
+        file: 'icon.png',
+        source: '../common/test/fixtures/icon.png',
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    const copied = await readFile(join(dir, 'android/app/src/main/res/drawable/icon.png'));
+    const source = await readFile('../common/test/fixtures/icon.png');
+    expect(copied.equals(source)).toBe(true);
+  });
+
+  it('should warn and continue when a resource operation fails', async () => {
+    const op = makeOp('android', 'res', [
+      {
+        path: 'drawable',
+        file: 'missing.png',
+        source: '../common/test/fixtures/does-not-exist.png',
+      },
+      {
+        path: 'raw',
+        file: 'auth_config.json',
+        text: '{}',
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    const file = await readFile(join(dir, 'android/app/src/main/res/raw/auth_config.json'), {
+      encoding: 'utf-8',
+    });
+    expect(file).toBe('{}');
   });
 
   it('should not add a resource file on a dry run', async () => {
     ctx.args.dryRun = true;
 
-    await Op(ctx, op);
+    const op = makeOp('android', 'res', [
+      {
+        path: 'raw',
+        file: 'auth_config.json',
+        text: '{ "client_id": "abc123" }',
+      },
+    ]);
 
-    expect(await pathExists(resFile)).toBe(false);
+    await Op(ctx, op as Operation);
+
+    expect(await pathExists(join(dir, 'android/app/src/main/res/raw/auth_config.json'))).toBe(false);
   });
 });

--- a/packages/configure/test/ops/ios.buildSettings.test.ts
+++ b/packages/configure/test/ops/ios.buildSettings.test.ts
@@ -1,0 +1,76 @@
+import { copy, rm } from '@ionic/utils-fs';
+import { temporaryDirectory } from 'tempy';
+
+import { Context, loadContext } from '../../src/ctx';
+import { Operation } from '../../src/definitions';
+import Op from '../../src/operations/ios/buildSettings';
+
+import { makeOp } from '../utils';
+
+describe('op: ios.buildSettings', () => {
+  let dir: string;
+  let ctx: Context;
+
+  beforeEach(async () => {
+    dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/ios-and-android', dir);
+
+    ctx = await loadContext(dir);
+    ctx.args.quiet = true;
+  });
+
+  afterEach(async () => {
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should set build settings', async () => {
+    const op = makeOp('ios', 'buildSettings', {
+      SWIFT_VERSION: '5.0',
+      DEVELOPMENT_TEAM: 'ABCD1234',
+    });
+
+    await Op(ctx, op as Operation);
+
+    expect(ctx.project.ios?.getBuildProperty(null, null, 'SWIFT_VERSION')).toBe('5.0');
+    expect(ctx.project.ios?.getBuildProperty(null, null, 'DEVELOPMENT_TEAM')).toBe('ABCD1234');
+  });
+
+  it('should write build settings to the pbxproj on commit', async () => {
+    const op = makeOp('ios', 'buildSettings', {
+      SWIFT_VERSION: '5.0',
+    });
+
+    await Op(ctx, op as Operation);
+    await ctx.project.commit();
+
+    const reloaded = await loadContext(dir);
+    expect(reloaded.project.ios?.getBuildProperty(null, null, 'SWIFT_VERSION')).toBe('5.0');
+  });
+
+  // Xcode has no boolean type, build settings are the strings YES and NO
+  it('should convert booleans to YES and NO', async () => {
+    const op = makeOp('ios', 'buildSettings', {
+      ENABLE_BITCODE: false,
+      SWIFT_COMPILATION_MODE: true,
+    });
+
+    await Op(ctx, op as Operation);
+
+    expect(ctx.project.ios?.getBuildProperty(null, null, 'ENABLE_BITCODE')).toBe('NO');
+    expect(ctx.project.ios?.getBuildProperty(null, null, 'SWIFT_COMPILATION_MODE')).toBe('YES');
+  });
+
+  it('should set build settings for a single build configuration', async () => {
+    const op: Operation = {
+      ...makeOp('ios', 'buildSettings', { FAKE_PROPERTY: 'debug only' }),
+      iosTarget: 'App',
+      iosBuild: 'Debug',
+    };
+
+    await Op(ctx, op);
+
+    expect(ctx.project.ios?.getBuildProperty('App', 'Debug', 'FAKE_PROPERTY')).toBe('debug only');
+    expect(ctx.project.ios?.getBuildProperty('App', 'Release', 'FAKE_PROPERTY')).not.toBe('debug only');
+  });
+});

--- a/packages/configure/test/ops/ios.frameworks.test.ts
+++ b/packages/configure/test/ops/ios.frameworks.test.ts
@@ -1,0 +1,51 @@
+import { copy, rm } from '@ionic/utils-fs';
+import { temporaryDirectory } from 'tempy';
+
+import { Context, loadContext } from '../../src/ctx';
+import { Operation } from '../../src/definitions';
+import Op from '../../src/operations/ios/frameworks';
+
+import { makeOp } from '../utils';
+
+describe('op: ios.frameworks', () => {
+  let dir: string;
+  let ctx: Context;
+
+  beforeEach(async () => {
+    dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/ios-and-android', dir);
+
+    ctx = await loadContext(dir);
+    ctx.args.quiet = true;
+  });
+
+  afterEach(async () => {
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should add frameworks to the app target', async () => {
+    const op = makeOp('ios', 'frameworks', [
+      'ImageIO.framework',
+      'libsqlite3.tbd',
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    expect(ctx.project.ios?.getFrameworks(null)).toEqual(
+      expect.arrayContaining(['ImageIO.framework', 'libsqlite3.tbd']),
+    );
+  });
+
+  it('should add frameworks to a non-app target', async () => {
+    const op: Operation = {
+      ...makeOp('ios', 'frameworks', ['WebKit.framework']),
+      iosTarget: 'My App Clip',
+    };
+
+    await Op(ctx, op);
+
+    expect(ctx.project.ios?.getFrameworks('My App Clip')).toContain('WebKit.framework');
+    expect(ctx.project.ios?.getFrameworks('App')).not.toContain('WebKit.framework');
+  });
+});

--- a/packages/configure/test/ops/ios.project.test.ts
+++ b/packages/configure/test/ops/ios.project.test.ts
@@ -1,0 +1,75 @@
+import { copy, rm } from '@ionic/utils-fs';
+import { temporaryDirectory } from 'tempy';
+
+import { Context, loadContext } from '../../src/ctx';
+import { Operation } from '../../src/definitions';
+import Op from '../../src/operations/ios/project';
+
+import { makeOp } from '../utils';
+
+describe('op: ios.bundleId/displayName/productName', () => {
+  let dir: string;
+  let ctx: Context;
+
+  beforeEach(async () => {
+    dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/ios-and-android', dir);
+
+    ctx = await loadContext(dir);
+    ctx.args.quiet = true;
+  });
+
+  afterEach(async () => {
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should set the bundle id', async () => {
+    const op = makeOp('ios', 'bundleId', 'io.ionic.betterBundleId');
+
+    await Op(ctx, op as Operation);
+
+    expect(ctx.project.ios?.getBundleId('App', 'Debug')).toBe('io.ionic.betterBundleId');
+    expect(ctx.project.ios?.getBundleId('App', 'Release')).toBe('io.ionic.betterBundleId');
+  });
+
+  it('should set the bundle id of a single target', async () => {
+    const op: Operation = {
+      ...makeOp('ios', 'bundleId', 'io.ionic.clipBundleId'),
+      iosTarget: 'My App Clip',
+    };
+
+    await Op(ctx, op);
+
+    expect(ctx.project.ios?.getBundleId('My App Clip')).toBe('io.ionic.clipBundleId');
+    expect(ctx.project.ios?.getBundleId('App')).toBe('io.ionic.wowzaStarter');
+  });
+
+  it('should set the display name', async () => {
+    const op = makeOp('ios', 'displayName', 'My Awesome App');
+
+    await Op(ctx, op as Operation);
+
+    expect(await ctx.project.ios?.getDisplayName('App')).toBe('My Awesome App');
+  });
+
+  // setProductName writes the PRODUCT_NAME build setting, getProductName reads the
+  // pbx target attribute, so the build property is what has to be asserted here
+  it('should set the product name', async () => {
+    const op = makeOp('ios', 'productName', 'Awesome App');
+
+    await Op(ctx, op as Operation);
+
+    expect(ctx.project.ios?.getBuildProperty('App', null, 'PRODUCT_NAME')).toBe('Awesome App');
+  });
+
+  it('should warn instead of throwing when the target does not exist', async () => {
+    const op: Operation = {
+      ...makeOp('ios', 'bundleId', 'io.ionic.betterBundleId'),
+      iosTarget: 'No Such Target',
+    };
+
+    await expect(Op(ctx, op)).resolves.toBeUndefined();
+    expect(ctx.project.ios?.getBundleId('App')).toBe('io.ionic.wowzaStarter');
+  });
+});

--- a/packages/configure/test/ops/ios.xml.test.ts
+++ b/packages/configure/test/ops/ios.xml.test.ts
@@ -106,4 +106,92 @@ describe('op: ios.xml', () => {
     `.trim());
   });
 
+  it('should inject nodes', async () => {
+    const op: IosXmlOperation = makeOp('ios', 'xml', [
+      {
+        file: 'xml-file.xml',
+        target: 'plist/dict',
+        inject: `<key>com.apple.security.application-groups</key>`
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    await ctx.project.commit();
+
+    const file = await readFile(join(dir, 'ios', 'App', 'xml-file.xml'), { encoding: 'utf-8' });
+    expect(file.trim()).toBe(`
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.developer.parent-application-identifiers</key>
+        <array>
+            <string>$(AppIdentifierPrefix)io.ionic.wowzaStarter</string>
+        </array>
+        <key>com.apple.security.application-groups</key>
+    </dict>
+</plist>
+    `.trim());
+  });
+
+  it('should merge nodes', async () => {
+    const op: IosXmlOperation = makeOp('ios', 'xml', [
+      {
+        file: 'xml-file.xml',
+        target: 'plist/dict/array',
+        merge: `
+        <array>
+          <string>$(AppIdentifierPrefix)io.ionic.otherStarter</string>
+        </array>
+        `
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    await ctx.project.commit();
+
+    const file = await readFile(join(dir, 'ios', 'App', 'xml-file.xml'), { encoding: 'utf-8' });
+    expect(file.trim()).toBe(`
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.developer.parent-application-identifiers</key>
+        <array>
+            <string>$(AppIdentifierPrefix)io.ionic.otherStarter</string>
+        </array>
+    </dict>
+</plist>
+    `.trim());
+  });
+
+  it('should replace nodes', async () => {
+    const op: IosXmlOperation = makeOp('ios', 'xml', [
+      {
+        file: 'xml-file.xml',
+        target: 'plist/dict/array',
+        replace: `<array><string>$(AppIdentifierPrefix)io.ionic.otherStarter</string></array>`
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    await ctx.project.commit();
+
+    const file = await readFile(join(dir, 'ios', 'App', 'xml-file.xml'), { encoding: 'utf-8' });
+    expect(file.trim()).toBe(`
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.developer.parent-application-identifiers</key>
+        <array>
+            <string>$(AppIdentifierPrefix)io.ionic.otherStarter</string>
+        </array>
+    </dict>
+</plist>
+    `.trim());
+  });
 });

--- a/packages/configure/test/project.test.ts
+++ b/packages/configure/test/project.test.ts
@@ -1,0 +1,37 @@
+import { Args } from '../src/ctx';
+import { loadProject } from '../src/project';
+
+describe('project loading', () => {
+  const dir = '../common/test/fixtures/ios-and-android';
+
+  // --ios and --android select the platforms to configure. Passing neither, or both,
+  // enables both platforms
+  const platformSelections: [Args, boolean, boolean][] = [
+    [{}, true, true],
+    [{ ios: true }, true, false],
+    [{ android: true }, false, true],
+    [{ ios: true, android: true }, true, true],
+  ];
+
+  it.each(platformSelections)(
+    'should enable the platforms selected by %o',
+    async (args, iosEnabled, androidEnabled) => {
+      const project = await loadProject(args, dir, 'android', 'ios/App');
+
+      expect(!!project.ios).toBe(iosEnabled);
+      expect(!!project.android).toBe(androidEnabled);
+    },
+  );
+
+  it('should not require a platform that was not selected', async () => {
+    const iosOnlyDir = '../common/test/fixtures/ios-only';
+
+    await expect(loadProject({}, iosOnlyDir, 'android', 'ios/App')).rejects.toThrow(
+      /Unable to find Android project/,
+    );
+
+    const project = await loadProject({ ios: true }, iosOnlyDir, 'android', 'ios/App');
+    expect(project.android).toBeNull();
+    expect(project.ios).not.toBeNull();
+  });
+});

--- a/packages/configure/test/tasks/run.test.ts
+++ b/packages/configure/test/tasks/run.test.ts
@@ -486,7 +486,7 @@ describe('task: run', () => {
     const ctx = await loadContext(dir);
     ctx.args.y = false;
     ctx.args.quiet = true;
-    ctx.args.noCommit = false;
+    ctx.args.commit = true;
 
     vi.mocked(logPrompt).mockClear();
 
@@ -495,6 +495,59 @@ describe('task: run', () => {
 
     expect(ctx.project.vfs.modifiedFiles()).toEqual([]);
     expect(logPrompt).not.toHaveBeenCalled();
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should apply the changes when the user confirms', async () => {
+    const dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/project-only', dir);
+
+    const ctx = await loadContext(dir);
+    ctx.args.y = false;
+    ctx.args.quiet = true;
+    ctx.args.commit = true;
+    ctx.args.dryRun = false;
+
+    vi.mocked(logPrompt).mockReset();
+    vi.mocked(logPrompt).mockResolvedValue({ apply: true });
+
+    await runCommand(ctx, '../common/test/fixtures/project.basic.yml');
+
+    expect(logPrompt).toHaveBeenCalledOnce();
+
+    const json = await readFile(join(dir, 'project-json.json'), { encoding: 'utf-8' });
+    expect(json).toContain('"project_id": "asdf"');
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('should not write anything when the user declines', async () => {
+    const dir = temporaryDirectory();
+
+    await copy('../common/test/fixtures/project-only', dir);
+
+    const json = join(dir, 'project-json.json');
+    const xml = join(dir, 'project-xml-strings.xml');
+    const before = await readUntouched([json, xml]);
+
+    const ctx = await loadContext(dir);
+    ctx.args.y = false;
+    ctx.args.quiet = true;
+    ctx.args.commit = true;
+    ctx.args.dryRun = false;
+
+    vi.mocked(logPrompt).mockReset();
+    vi.mocked(logPrompt).mockResolvedValue({ apply: false });
+
+    const lines = await captureLoggedLines(() =>
+      runCommand(ctx, '../common/test/fixtures/project.basic.yml'),
+    );
+
+    expect(logPrompt).toHaveBeenCalledOnce();
+    expect(lines).toContainEqual(expect.stringContaining('Not applying changes'));
+    expect(await readUntouched([json, xml])).toEqual(before);
 
     await rm(dir, { force: true, recursive: true });
   });

--- a/packages/project/src/android/gradle-file.ts
+++ b/packages/project/src/android/gradle-file.ts
@@ -10,6 +10,11 @@ import { AndroidGradleInjectType } from '../definitions';
 import { Logger } from '../logger';
 import { assertParentDirs } from '../util/fs';
 
+// Windows does not expand the lib/* wildcard the POSIX classpath uses, so every jar
+// vendored by @trapezedev/gradle-parse has to be listed here explicitly
+export const WINDOWS_GRADLE_PARSE_CLASSPATH =
+  'lib/groovy-3.0.9.jar;lib/json-20260814.jar;capacitor-gradle-parse.jar;.';
+
 export type GradleAST = any;
 export interface GradleASTNode {
   type: string;
@@ -317,7 +322,7 @@ export class GradleFile extends VFSStorable {
           java,
           [
             '-cp',
-            'lib/groovy-3.0.9.jar;lib/json-20260814.jar;capacitor-gradle-parse.jar;.',
+            WINDOWS_GRADLE_PARSE_CLASSPATH,
             'com.capacitorjs.gradle.Parse',
             tempFile,
           ],

--- a/packages/project/test/frameworks/detection.test.ts
+++ b/packages/project/test/frameworks/detection.test.ts
@@ -1,0 +1,96 @@
+import { rm, writeFile } from '@ionic/utils-fs';
+import { join } from 'path';
+import { temporaryDirectory } from 'tempy';
+
+import { Framework } from '../../src/frameworks';
+import { CapacitorFramework } from '../../src/frameworks/capacitor';
+import { CordovaFramework } from '../../src/frameworks/cordova';
+import { DotNetMauiFramework } from '../../src/frameworks/dotnet-maui';
+import { FlutterFramework } from '../../src/frameworks/flutter';
+import { NativeAndroidFramework } from '../../src/frameworks/native-android';
+import { NativeIosFramework } from '../../src/frameworks/native-ios';
+import { NativeScriptFramework } from '../../src/frameworks/nativescript';
+import { ReactNativeFramework } from '../../src/frameworks/react-native';
+import { MobileProject } from '../../src/project';
+
+async function loadProject(projectRoot: string) {
+  const project = new MobileProject(projectRoot);
+  await project.load();
+  return project;
+}
+
+describe('frameworks: detection', () => {
+  const fixtures: [string, typeof Framework][] = [
+    ['frameworks/flutter_configure_test', FlutterFramework],
+    ['frameworks/ReactNativeProject', ReactNativeFramework],
+    ['frameworks/ReactNativeExpo', ReactNativeFramework],
+    ['ios-and-android', CapacitorFramework],
+    ['frameworks/CordovaApp', CordovaFramework],
+    ['frameworks/DotNetMauiApp', DotNetMauiFramework],
+    ['frameworks/NativeScriptApp', NativeScriptFramework],
+    ['frameworks/NativeIosApp', NativeIosFramework],
+    ['frameworks/NativeAndroidApp', NativeAndroidFramework],
+  ];
+
+  it.each(fixtures)('should detect the framework of %s', async (fixture, framework) => {
+    const project = await loadProject(`../common/test/fixtures/${fixture}`);
+
+    expect(project.framework).toBeInstanceOf(framework);
+  });
+
+  it('should not detect a framework whose marker files are missing', async () => {
+    const project = new MobileProject('../common/test/fixtures/ios-and-android');
+
+    expect(await FlutterFramework.getFramework(project)).toBeNull();
+    expect(await ReactNativeFramework.getFramework(project)).toBeNull();
+    expect(await CordovaFramework.getFramework(project)).toBeNull();
+    expect(await DotNetMauiFramework.getFramework(project)).toBeNull();
+    expect(await NativeScriptFramework.getFramework(project)).toBeNull();
+    expect(await NativeIosFramework.getFramework(project)).toBeNull();
+    expect(await NativeAndroidFramework.getFramework(project)).toBeNull();
+  });
+
+  it('should detect no framework at all for a project without markers', async () => {
+    const dir = temporaryDirectory();
+
+    const project = await loadProject(dir);
+    expect(project.framework).toBeNull();
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  // The detection order in MobileProject.detectFramework decides which framework wins when
+  // several match: the cross-platform frameworks come first, the native ones last
+  describe('detection order', () => {
+    let dir: string;
+
+    beforeEach(() => {
+      dir = temporaryDirectory();
+    });
+
+    afterEach(async () => {
+      await rm(dir, { force: true, recursive: true });
+    });
+
+    it('should prefer Flutter over Capacitor', async () => {
+      await writeFile(join(dir, 'pubspec.yaml'), 'name: app\n');
+      await writeFile(join(dir, 'capacitor.config.json'), '{}');
+
+      expect((await loadProject(dir)).framework).toBeInstanceOf(FlutterFramework);
+    });
+
+    it('should prefer Capacitor over Cordova', async () => {
+      await writeFile(join(dir, 'capacitor.config.json'), '{}');
+      await writeFile(join(dir, 'config.xml'), '<widget />');
+
+      expect((await loadProject(dir)).framework).toBeInstanceOf(CapacitorFramework);
+    });
+
+    it('should prefer Capacitor over the native frameworks', async () => {
+      await writeFile(join(dir, 'capacitor.config.json'), '{}');
+      await writeFile(join(dir, 'build.gradle'), '');
+
+      expect((await loadProject(dir)).framework).toBeInstanceOf(CapacitorFramework);
+    });
+  });
+});

--- a/packages/project/test/gradle-file.android.test.ts
+++ b/packages/project/test/gradle-file.android.test.ts
@@ -1,7 +1,8 @@
 import { AndroidGradleInjectType, MobileProject } from '../src';
 import { MobileProjectConfig } from '../src/config';
-import { GradleFile } from '../src/android/gradle-file';
+import { GradleFile, WINDOWS_GRADLE_PARSE_CLASSPATH } from '../src/android/gradle-file';
 
+import { readdir } from '@ionic/utils-fs';
 import { join } from 'path';
 import { VFS } from '../src/vfs';
 
@@ -36,6 +37,23 @@ describe('project - android - gradle', () => {
 
     const output = await gradle.parse();
     expect(output).not.toBeNull();
+  });
+
+  // The Windows classpath lists the vendored jars by name, so bumping one without updating
+  // it would break gradle parsing on Windows only
+  it('Should list every vendored jar in the Windows classpath', async () => {
+    const gradle = new GradleFile(
+      join(project.config.android!.path!, 'build.gradle'),
+      vfs,
+    );
+    const jars = (await readdir(join(gradle.getGradleParserPath(), 'lib'))).filter(f =>
+      f.endsWith('.jar'),
+    );
+
+    expect(jars.length).toBeGreaterThan(0);
+    for (const jar of jars) {
+      expect(WINDOWS_GRADLE_PARSE_CLASSPATH).toContain(`lib/${jar}`);
+    }
   });
 
   it('Should find target element in parsed Gradle', async () => {

--- a/packages/project/test/json-file.test.ts
+++ b/packages/project/test/json-file.test.ts
@@ -1,5 +1,12 @@
+import { copy, readFile, rm } from '@ionic/utils-fs';
+import { join } from 'path';
+import { temporaryDirectory } from 'tempy';
+
 import { JsonFile } from '../src/json';
+import { MobileProject } from '../src/project';
 import { VFS } from '../src/vfs';
+
+const fixture = '../common/test/fixtures/json-file.json';
 
 describe('json file', () => {
   let vfs: VFS;
@@ -7,7 +14,7 @@ describe('json file', () => {
 
   beforeEach(async () => {
     vfs = new VFS();
-    file = new JsonFile('../common/test/fixtures/json-file.json', vfs);
+    file = new JsonFile(fixture, vfs);
     await file.load();
   });
 
@@ -56,5 +63,35 @@ describe('json file', () => {
         color: 'blue',
       },
     });
+  });
+
+  it('Should write the document on commit', async () => {
+    const dir = temporaryDirectory();
+    const path = join(dir, 'json-file.json');
+    await copy(fixture, path);
+
+    const tempVfs = new VFS();
+    const tempFile = new JsonFile(path, tempVfs);
+    await tempFile.load();
+    await tempFile.merge({ info: { color: 'blue' } });
+
+    await tempVfs.commitAll({} as MobileProject);
+
+    const contents = await readFile(path, { encoding: 'utf-8' });
+    expect(JSON.parse(contents)).toMatchObject({
+      name: 'json',
+      info: { age: 34, color: 'blue' },
+    });
+    expect(contents).toContain('\n  "name": "json"');
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('Should not reload a file that is already open', async () => {
+    await file.set({ name: 'Jason' });
+    await file.load();
+
+    expect(file.getDocument()).toMatchObject({ name: 'Jason' });
+    expect(Object.keys(vfs.all())).toEqual([fixture]);
   });
 });

--- a/packages/project/test/plist-file.test.ts
+++ b/packages/project/test/plist-file.test.ts
@@ -1,14 +1,21 @@
+import { copy, readFile, rm } from '@ionic/utils-fs';
+import { join } from 'path';
+import { temporaryDirectory } from 'tempy';
+
 import { PlistFile } from '../src/plist';
+import { MobileProject } from '../src/project';
 import { serializeXml } from '../src/util/xml';
 import { VFS } from '../src/vfs';
 
-describe('xml file', () => {
+const fixture = '../common/test/fixtures/ios-and-android/ios/App/My App Clip/AppClip.plist';
+
+describe('plist file', () => {
   let vfs: VFS;
   let file: PlistFile;
 
   beforeEach(async () => {
     vfs = new VFS();
-    file = new PlistFile('../common/test/fixtures/ios-and-android/ios/App/My App Clip/AppClip.plist', vfs);
+    file = new PlistFile(fixture, vfs);
     await file.load();
   });
 
@@ -52,5 +59,41 @@ describe('xml file', () => {
         Bar: true
       }
     });
+  });
+
+  it('Should write the document on commit', async () => {
+    const dir = temporaryDirectory();
+    const path = join(dir, 'AppClip.plist');
+    await copy(fixture, path);
+
+    const tempVfs = new VFS();
+    const tempFile = new PlistFile(path, tempVfs);
+    await tempFile.load();
+    await tempFile.merge({ NSFaceIDUsageDescription: 'Log in' });
+
+    await tempVfs.commitAll({} as MobileProject);
+
+    const contents = await readFile(path, { encoding: 'utf-8' });
+    // Xcode indents plists with tabs
+    expect(contents).toContain('\n\t<dict>');
+
+    const reloaded = new PlistFile(path, new VFS());
+    await reloaded.load();
+    expect(reloaded.getDocument()).toMatchObject({
+      NSFaceIDUsageDescription: 'Log in',
+      NSAppClip: {
+        NSAppClipRequestEphemeralUserNotification: false
+      }
+    });
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('Should not reload a file that is already open', async () => {
+    await file.set({ NSFaceIDUsageDescription: 'Log in' });
+    await file.load();
+
+    expect(file.getDocument()).toMatchObject({ NSFaceIDUsageDescription: 'Log in' });
+    expect(Object.keys(vfs.all())).toEqual([fixture]);
   });
 });

--- a/packages/project/test/plist-file.test.ts
+++ b/packages/project/test/plist-file.test.ts
@@ -4,7 +4,6 @@ import { temporaryDirectory } from 'tempy';
 
 import { PlistFile } from '../src/plist';
 import { MobileProject } from '../src/project';
-import { serializeXml } from '../src/util/xml';
 import { VFS } from '../src/vfs';
 
 const fixture = '../common/test/fixtures/ios-and-android/ios/App/My App Clip/AppClip.plist';

--- a/packages/project/test/strings-file.test.ts
+++ b/packages/project/test/strings-file.test.ts
@@ -1,6 +1,13 @@
+import { copy, readFile, rm } from '@ionic/utils-fs';
+import { join } from 'path';
+import { temporaryDirectory } from 'tempy';
+
 import { StringsFile } from '../src';
+import { MobileProject } from '../src/project';
 import { generateStrings } from '../src/util/strings';
 import { VFS } from '../src/vfs';
+
+const fixture = '../common/test/fixtures/strings.strings';
 
 describe('strings file', () => {
   let vfs: VFS;
@@ -8,7 +15,7 @@ describe('strings file', () => {
 
   beforeEach(async () => {
     vfs = new VFS();
-    file = new StringsFile('../common/test/fixtures/strings.strings', vfs);
+    file = new StringsFile(fixture, vfs);
     await file.load();
   });
 
@@ -151,6 +158,33 @@ describe('strings file', () => {
 
 "New key" = "Yes";
     `.trim());
+  });
+
+  it('Should write the document on commit', async () => {
+    const dir = temporaryDirectory();
+    const path = join(dir, 'Localizable.strings');
+    await copy(fixture, path);
+
+    const tempVfs = new VFS();
+    const tempFile = new StringsFile(path, tempVfs);
+    await tempFile.load();
+    await tempFile.set({ 'Insert Element': 'New1' });
+
+    await tempVfs.commitAll({} as MobileProject);
+
+    const contents = await readFile(path, { encoding: 'utf-8' });
+    expect(contents).toContain('"Insert Element" = "New1";');
+    expect(contents).toContain('/* Insert Element menu item */');
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('Should not reload a file that is already open', async () => {
+    await file.set({ 'Insert Element': 'New1' });
+    await file.load();
+
+    expect(generateStrings(file.getDocument())).toContain('"Insert Element" = "New1";');
+    expect(Object.keys(vfs.all())).toEqual([fixture]);
   });
 
   it('Should set from JSON file', async () => {

--- a/packages/project/test/xcconfig-file.test.ts
+++ b/packages/project/test/xcconfig-file.test.ts
@@ -1,7 +1,12 @@
+import { copy, readFile, rm } from '@ionic/utils-fs';
+import { join } from 'path';
+import { temporaryDirectory } from 'tempy';
+
 import { XCConfigFile } from '../src';
+import { MobileProject } from '../src/project';
 import { VFS } from '../src/vfs';
 
-describe('strings file', () => {
+describe('xcconfig file', () => {
   let vfs: VFS;
   let file: XCConfigFile;
 
@@ -99,5 +104,35 @@ TARGETED_DEVICE_FAMILY = 4;
 KEY_ONLY = VALUE_ONLY
 FOO[sdk=<sdk>][arch=<arch>] = new
     `.trim());
+  });
+
+  it('Should write the document on commit', async () => {
+    const dir = temporaryDirectory();
+    const path = join(dir, 'Config.xcconfig');
+    await copy('../common/test/fixtures/test.xcconfig', path);
+
+    file = new XCConfigFile(path, vfs);
+    await file.load();
+    await file.set({ KEY: 'value', NEW_KEY: 'new value' });
+
+    await vfs.commitAll({} as MobileProject);
+
+    const contents = await readFile(path, { encoding: 'utf-8' });
+    expect(contents).toContain('KEY = value');
+    expect(contents).toContain('NEW_KEY = new value');
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('Should not reload a file that is already open', async () => {
+    const path = '../common/test/fixtures/test.xcconfig';
+    file = new XCConfigFile(path, vfs);
+    await file.load();
+
+    await file.set({ KEY: 'value' });
+    await file.load();
+
+    expect(file.getPairs()).toMatchObject({ KEY: 'value' });
+    expect(Object.keys(vfs.all())).toEqual([path]);
   });
 });

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -3,8 +3,11 @@ import { copy, readFile, rm } from '@ionic/utils-fs';
 import { temporaryDirectory } from 'tempy';
 
 import { Logger, XmlFile } from '../src';
+import { MobileProject } from '../src/project';
 import { formatXml, serializeXml } from '../src/util/xml';
 import { VFS } from '../src/vfs';
+
+const fixture = '../common/test/fixtures/ios-and-android/android/app/src/main/res/values/strings.xml';
 
 describe('xml file', () => {
   let vfs: VFS;
@@ -12,7 +15,7 @@ describe('xml file', () => {
 
   beforeEach(async () => {
     vfs = new VFS();
-    file = new XmlFile('../common/test/fixtures/ios-and-android/android/app/src/main/res/values/strings.xml', vfs);
+    file = new XmlFile(fixture, vfs);
     await file.load();
   });
 
@@ -200,6 +203,40 @@ describe('xml file', () => {
     <string name="package_name">io.ionic.starter</string>
     <string name="custom_url_scheme">io.ionic.starter</string>
 </resources>`.trim());
+  });
+
+  it('Should write the document on commit', async () => {
+    const dir = temporaryDirectory();
+    const path = join(dir, 'strings.xml');
+    await copy(fixture, path);
+
+    const tempVfs = new VFS();
+    const tempFile = new XmlFile(path, tempVfs);
+    await tempFile.load();
+    tempFile.replaceFragment('resources/string[@name="app_name"]', `<string name="app_name">Awesome App</string>`);
+
+    await tempVfs.commitAll({} as MobileProject);
+
+    const contents = await readFile(path, { encoding: 'utf-8' });
+    expect(contents.trim()).toBe(`
+<?xml version='1.0' encoding='utf-8' ?>
+<resources>
+    <string name="app_name">Awesome App</string>
+    <string name="title_activity_main">capacitor-configure-test</string>
+    <string name="package_name">io.ionic.starter</string>
+    <string name="custom_url_scheme">io.ionic.starter</string>
+</resources>
+    `.trim());
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it('Should not reload a file that is already open', async () => {
+    file.setAttrs('/resources', { test: 'thing' });
+    await file.load();
+
+    expect(file.getDocumentElement()?.getAttribute('test')).toBe('thing');
+    expect(Object.keys(vfs.all())).toEqual([fixture]);
   });
 
   // The XML formatter must never re-space text nodes: doing so silently rewrites values


### PR DESCRIPTION
The test suite is broad but shallow on the paths that decide whether trapeze writes the right bytes to disk. This PR adds depth there, and fixes one display-only bug the new assertions exposed.

## Fix

**`ios.plist` always reported "0 modifications"** (`packages/configure/src/op.ts`). The documented `plist` form is a list of entry groups, so `op.value.entries` resolved to `Array.prototype.entries` — a function whose `.length` is its arity, `0`. Every `trapeze run` with a plist operation printed `run ios plist 0 modifications`. Both the list form and the legacy object form now count the entries of every group.

Verified failing without the fix: `expected '0 modifications' to be '2 modifications'` and `expected '1 modifications' to be '1 modification'`.

## Tests

Everything below asserts behaviour that is already correct on `main`; only the two plist display-text tests fail without the fix above.

- **Interactive apply flow** (`test/tasks/run.test.ts`) — the "Apply changes?" confirmation had never been executed by a test. Added the accepted path (files land on disk) and the declined path (contents and mtimes unchanged, "Not applying changes" logged). Also fixed a dead `ctx.args.noCommit = false` in the neighbouring test — `run.ts` reads `ctx.args.commit`.
- **`--ios` / `--android` selection** (new `test/project.test.ts`) — table-driven over the four flag combinations, plus a case showing an unselected platform is not required to exist.
- **Operation modules with no test file** — `ios.buildSettings` (including the boolean → `YES`/`NO` conversion), `ios.bundleId`/`displayName`/`productName`, `ios.frameworks`, `android.packageName`, `android.res` (text and source forms).
- **`ios.xml` modes** — `inject`, `merge` and `replace` ported from the android/project xml tests. Only `delete`/`deleteAttributes` were covered before.
- **Framework detection** (new `packages/project/test/frameworks/detection.test.ts`) — `MobileProject.detectFramework()` was never called by a test and `project.framework` never asserted. Covers each framework fixture, the negative case per detector, an empty project, and the precedence order (`Flutter > Capacitor > Cordova > native`) that the ordered probe list exists to resolve.
- **File wrapper commit + reload** (`xml`, `plist`, `json`, `strings`, `xcconfig`) — no project-package test committed a wrapper before, so the serialization half of each was only exercised indirectly from the other package. Each now mutates, commits, and asserts the bytes on disk (tab-indented plists, 2-space json, …), and asserts that loading an already open file keeps pending changes.
- **Windows gradle classpath** — the win32 branch lists the vendored jars explicitly while POSIX uses `lib/*`, so a jar bump breaks Windows only, silently. Extracted the string as `WINDOWS_GRADLE_PARSE_CLASSPATH` and added a pure string test asserting every jar in the resolved `@trapezedev/gradle-parse/lib` appears in it.

## Verification

```
npm run build                                    ok
packages/project   npx vitest run    22 files / 184 tests passed  (was 21 / 159)
packages/configure npx vitest run    29 files / 110 tests passed  (was 23 /  82)
```

## Out of scope

Left deliberately for the in-flight fix PRs, whose tests ship with them: `--dry-run`/`--no-commit` vs `copy`/`res`, the `attrs:` wiring of `ios.xml`/`project.xml`, the `--diff` pipeline and the wrappers that register no diff function, and the properties double-load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
