### PR TITLE
fix: repair pbxproj value round-trips, literal YAML keys, and unsafe Android package renames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,11 @@ permissions:
   issues: write
   pull-requests: write
 
+# Same toolchain as ci.yml, so the published artifacts are built on a version CI covers
 env:
-  NODE_VERSION: 24
+  NODE_VERSION: 20
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: temurin
 
 jobs:
   release:
@@ -28,10 +31,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+      # Gradle tests shell out to java; don't rely on the JDK preinstalled in the runner image
+      - uses: actions/setup-java@v4
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - run: npm ci
       # Scoped to the published packages; the private website is covered by CI
       - run: npm run build -- --filter='@trapezedev/*'
+      - run: npm run typecheck -- --filter='@trapezedev/*'
       - run: npm test -- --filter='@trapezedev/*'
+      # Catches packaging breakage (files/bin/exports) that unit tests can't see
+      - run: node scripts/smoke.mjs
       - name: Create release pull request or GitHub release
         id: release-please
         uses: googleapis/release-please-action@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -21768,14 +21768,16 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.14.175",
+        "@types/plist": "^3.0.2",
         "@types/prompts": "^2.0.14",
+        "plist": "^3.0.4",
         "rimraf": "^6.0.1",
         "tempy": "^3.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "packages/configure/node_modules/picomatch": {
@@ -22033,7 +22035,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "packages/project/node_modules/picomatch": {

--- a/packages/common/test/fixtures/ios.var.keys.yml
+++ b/packages/common/test/fixtures/ios.var.keys.yml
@@ -17,3 +17,7 @@ platforms:
                   $BUNDLE_ID: $PROFILE
               - serializedKeys:
                   $PROFILE_MAP: My iOS Profiles
+              - literalKeys:
+                  $schema: ./schema.json
+                  prefix_$BUNDLE_ID: Interpolated
+                  prefix_$UNDECLARED: Literal

--- a/packages/common/test/fixtures/no-default-config.gradle
+++ b/packages/common/test/fixtures/no-default-config.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'com.android.application'
+
+android {
+    namespace "io.ionic.starter"
+    compileSdk 35
+}

--- a/packages/common/test/fixtures/version-assignments.gradle
+++ b/packages/common/test/fixtures/version-assignments.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'com.android.application'
+
+android {
+    namespace = "io.ionic.starter"
+    defaultConfig {
+        applicationId = "io.ionic.starter"
+        versionCode = 4
+        versionName = "1.0"
+        versionNameSuffix = "beta"
+    }
+}

--- a/packages/configure/package.json
+++ b/packages/configure/package.json
@@ -22,7 +22,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@ionic/cli-framework-output": "^2.2.2",
@@ -46,7 +46,9 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.175",
+    "@types/plist": "^3.0.2",
     "@types/prompts": "^2.0.14",
+    "plist": "^3.0.4",
     "rimraf": "^6.0.1",
     "tempy": "^3.1.0",
     "typescript": "^5.9.3",

--- a/packages/configure/src/tasks/run.ts
+++ b/packages/configure/src/tasks/run.ts
@@ -38,6 +38,8 @@ export async function runCommand(ctx: Context, configFile: YamlFile) {
 
 // A platform project that fails to load stores the error instead of throwing, and every
 // operation on it then fails with a misleading message, so report the real cause up front.
+// The run continues so the other platform is still configured, but it exits non-zero so
+// that CI notices the operations that were silently dropped.
 function printPlatformLoadErrors(ctx: Context) {
   const iosError = ctx.project.ios?.getError();
   if (iosError) {
@@ -47,6 +49,10 @@ function printPlatformLoadErrors(ctx: Context) {
   const androidError = ctx.project.android?.getError();
   if (androidError) {
     logger.error(`Unable to load the Android project: ${androidError.message}`);
+  }
+
+  if (iosError || androidError) {
+    process.exitCode = 1;
   }
 }
 

--- a/packages/configure/src/yaml-config.ts
+++ b/packages/configure/src/yaml-config.ts
@@ -120,12 +120,16 @@ function interpolateVarsInValue(ctx: Context, val: any) {
   return val;
 }
 
+// The same reference syntax `str` interpolates, so keys and values agree on what
+// counts as a variable
+const VARIABLE_REFERENCE = /\$[^\(\{\[][\w]+/g;
+
 // Array indices are passed through, and a key resolving to a JSON-valued
 // variable is coerced back to a string since it has to stay usable as a key.
 // Objects and arrays are serialized the same way `str` serializes them when
 // they are embedded in a string
 function interpolateKey(ctx: Context, key: string | number) {
-  if (typeof key !== 'string') {
+  if (typeof key !== 'string' || !isInterpolatable(ctx, key)) {
     return key;
   }
 
@@ -138,4 +142,13 @@ function interpolateKey(ctx: Context, key: string | number) {
   return typeof interped === 'object'
     ? JSON.stringify(interped)
     : String(interped);
+}
+
+// `str` drops references it cannot resolve, which would turn a literal key like
+// `$schema` into an empty one, so a key is only interpolated when every reference
+// in it is a declared variable
+function isInterpolatable(ctx: Context, key: string) {
+  const references = key.match(VARIABLE_REFERENCE);
+
+  return !!references && references.every(ref => !!ctx.vars[ref.slice(1)]);
 }

--- a/packages/configure/test/config.test.ts
+++ b/packages/configure/test/config.test.ts
@@ -41,6 +41,22 @@ describe('config loading', () => {
     });
   });
 
+  it('should only interpolate map keys whose variables are all declared', async () => {
+    const parsed = await loadYamlConfig(
+      ctx,
+      '../common/test/fixtures/ios.var.keys.yml',
+    );
+
+    expect(parsed.platforms.ios.targets.App.plist[0].entries[2]).toEqual({
+      literalKeys: {
+        // Not a variable reference, so it has to survive as written
+        $schema: './schema.json',
+        'prefix_com.ionicframework.testBundle': 'Interpolated',
+        'prefix_$UNDECLARED': 'Literal',
+      },
+    });
+  });
+
   it('should keep variable declarations intact', async () => {
     const parsed = await loadYamlConfig(
       ctx,

--- a/packages/configure/test/setup.ts
+++ b/packages/configure/test/setup.ts
@@ -9,4 +9,6 @@ const ORIGINAL_ENV = { ...process.env };
 afterEach(() => {
   process.argv = [...ORIGINAL_ARGV];
   process.env = { ...ORIGINAL_ENV };
+  // A run that reports a failure sets this, and vitest would exit with it
+  process.exitCode = 0;
 });

--- a/packages/configure/test/tasks/run.test.ts
+++ b/packages/configure/test/tasks/run.test.ts
@@ -149,7 +149,7 @@ describe('task: run', () => {
     });
   });
 
-  it('should commit operations to filesystem', async () => {
+  it('should commit operations to filesystem', { timeout: 120000 }, async () => {
     const dir = await useFixture('ios-and-android');
     await copy(fixturePath('basic.yml'), join(dir, 'basic.yml'));
 
@@ -228,7 +228,7 @@ describe('task: run', () => {
   });
 
   // TODO: Separate this out into multiple sub-tests
-  it('should commit operations to filesystem directly with y', async () => {
+  it('should commit operations to filesystem directly with y', { timeout: 120000 }, async () => {
     const dir = await useFixture('ios-and-android');
     await copy(fixturePath('basic.yml'), join(dir, 'basic.yml'));
 
@@ -387,6 +387,27 @@ describe('task: run', () => {
     expect(errors).toContainEqual(
       expect.stringContaining('Unable to load the iOS project'),
     );
+  });
+
+  it('should exit non-zero when a native project failed to load', async () => {
+    const dir = await useFixture('ios-and-android');
+    await writeFile(
+      join(dir, 'ios/App/App.xcodeproj/project.pbxproj'),
+      '// !$*UTF8*$!\n{ this is not a pbxproj }\n',
+    );
+
+    const ctx = await loadContext(dir);
+    ctx.args.commit = false;
+    ctx.args.quiet = true;
+
+    vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+    await runCommand(ctx, '../common/test/fixtures/project.basic.yml');
+
+    expect(process.exitCode).toBe(1);
+
+    // The run has to carry on so the operations that can be applied still are
+    expect(ctx.project.vfs.modifiedFiles()).not.toEqual([]);
   });
 
   it('should leave files alone that no operation modified', { timeout: 120000 }, async () => {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -18,7 +18,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@ionic/utils-fs": "^3.1.5",

--- a/packages/project/src/android/gradle-file.ts
+++ b/packages/project/src/android/gradle-file.ts
@@ -15,6 +15,12 @@ import { assertParentDirs } from '../util/fs';
 export const WINDOWS_GRADLE_PARSE_CLASSPATH =
   'lib/groovy-3.0.9.jar;lib/json-20260814.jar;capacitor-gradle-parse.jar;.';
 
+/**
+ * Thrown when neither the property to replace nor the block to insert it into exists,
+ * so callers can tell a missing target apart from a failed modification.
+ */
+export class GradleTargetNotFound extends Error {}
+
 export type GradleAST = any;
 export interface GradleASTNode {
   type: string;
@@ -96,10 +102,9 @@ export class GradleFile extends VFSStorable {
       const foundParent = this.find(parent, exact);
 
       if (foundParent.length) {
-        this.insertIntoGradleFile([toReplace], foundParent[0], type);
-        return;
+        return this.insertIntoGradleFile([toReplace], foundParent[0], type);
       } else {
-        throw new Error(
+        throw new GradleTargetNotFound(
           'Unable to find target in Gradle file to replace or insert',
         );
       }
@@ -606,15 +611,25 @@ export class GradleFile extends VFSStorable {
     if (source) {
       Logger.v('gradle', 'setApplicationId', `to ${applicationId} in ${this.filename}`);
 
-      return this.replaceProperties({
-        android: {
-          defaultConfig: {
-            applicationId: {}
+      try {
+        await this.replaceProperties({
+          android: {
+            defaultConfig: {
+              applicationId: {}
+            }
           }
+        }, {
+          applicationId: `"${applicationId}"`
+        });
+      } catch (e) {
+        // An app build.gradle without an android.defaultConfig block is valid, the
+        // applicationId then defaults to the namespace and there is nothing to set
+        if (!(e instanceof GradleTargetNotFound)) {
+          throw e;
         }
-      }, {
-        applicationId: `"${applicationId}"`
-      });
+
+        Logger.warn(`Unable to set the applicationId in ${this.filename}: no android.defaultConfig block found`);
+      }
     }
   }
 
@@ -654,7 +669,9 @@ export class GradleFile extends VFSStorable {
     const source = await this.getGradleSource();
 
     if (source) {
-      const versionCode = source.match(/versionCode\s+(\w+)/);
+      // The word boundary keeps properties that start with versionCode, such as the
+      // versionCodeOverride of an APK split, from being read as the version code
+      const versionCode = source.match(/versionCode\b\s*=?\s*(\w+)/);
       if (!versionCode) {
         return null;
       }
@@ -664,19 +681,15 @@ export class GradleFile extends VFSStorable {
   }
 
   async incrementVersionCode() {
-    const source = await this.getGradleSource();
+    const versionCode = await this.getVersionCode();
 
-    if (source) {
-      const versionCode = source.match(/versionCode\s+(\w+)/);
-      if (!versionCode) {
-        return;
-      }
-      const num = parseInt(versionCode[1]);
-      if (!isNaN(num)) {
-        Logger.v('gradle', 'incrementVersionCode', `to ${num} in ${this.filename}`);
-        return this.setVersionCode(num + 1);
-      }
+    if (versionCode === null || isNaN(versionCode)) {
+      return;
     }
+
+    Logger.v('gradle', 'incrementVersionCode', `to ${versionCode + 1} in ${this.filename}`);
+
+    return this.setVersionCode(versionCode + 1);
   }
 
   async setVersionName(versionName: string) {
@@ -701,7 +714,7 @@ export class GradleFile extends VFSStorable {
 
     if (source) {
       const versionName =
-        source.match(/versionName\s+["']([^"']+)["']/) || null;
+        source.match(/versionName\s*=?\s*["']([^"']+)["']/) || null;
       if (!versionName) {
         return null;
       }
@@ -734,7 +747,7 @@ export class GradleFile extends VFSStorable {
 
     if (source) {
       const versionName =
-        source.match(/versionNameSuffix\s+["']([^"']+)["']/) || null;
+        source.match(/versionNameSuffix\s*=?\s*["']([^"']+)["']/) || null;
       if (!versionName) {
         return null;
       }

--- a/packages/project/src/android/project.ts
+++ b/packages/project/src/android/project.ts
@@ -28,6 +28,9 @@ const LAUNCHER_ACTIVITY = 'manifest/application/activity[intent-filter/action/@a
 // The Capacitor string resources that hold a copy of the package name
 const PACKAGE_NAME_STRINGS = ['package_name', 'custom_url_scheme'];
 
+// Used when the manifest declares no activity to take the name from
+const DEFAULT_MAIN_ACTIVITY_NAME = 'MainActivity';
+
 export class AndroidProject extends PlatformProject {
   private manifest: XmlFile;
   private buildGradle: GradleFile | null = null;
@@ -219,21 +222,32 @@ export class AndroidProject extends PlatformProject {
   /**
    * Move every file of the old package, sub packages included, to the new package
    * directory and return the new file paths.
+   *
+   * Every destination is checked before the first file is moved, so a file that is in
+   * the way cannot leave the sources split across the old and the new package.
    */
   private async movePackageSources(oldPackageDir: string, newPackageDir: string) {
-    const movedFiles: string[] = [];
+    const files = (await listFilesRecursive(oldPackageDir)).map(file => ({
+      file,
+      dest: join(newPackageDir, relative(oldPackageDir, file)),
+    }));
 
-    for (const file of await listFilesRecursive(oldPackageDir)) {
-      const dest = join(newPackageDir, relative(oldPackageDir, file));
+    for (const { dest } of files) {
+      if (await pathExists(dest)) {
+        throw new Error(
+          `Unable to move the sources to the new package: a file already exists at ${dest}. Remove it before modifying the project package name`,
+        );
+      }
+    }
 
+    for (const { file, dest } of files) {
       Logger.v('android', 'setPackageName', `moving ${file} to ${dest}`);
 
       await mkdirp(dirname(dest));
       await move(file, dest);
-      movedFiles.push(dest);
     }
 
-    return movedFiles;
+    return files.map(({ dest }) => dest);
   }
 
   /**
@@ -241,7 +255,9 @@ export class AndroidProject extends PlatformProject {
    * source files. Sources that declare a package outside of the old one are left alone.
    */
   private async renamePackageInSources(files: string[], oldPackageName: string, packageName: string) {
-    const packageDeclaration = /(package\s+)([^\s;]+)/;
+    // Anchored to the start of a line so that the word package in a header comment is
+    // not mistaken for the declaration
+    const packageDeclaration = /^([ \t]*package\s+)([\w.]+)/m;
     const oldPackageImport = new RegExp(`(import\\s+(static\\s+)?)${oldPackageName.replace(/\./g, '\\.')}\\.`, 'g');
 
     for (const file of files.filter(f => /\.(java|kt)$/.test(f))) {
@@ -339,16 +355,25 @@ export class AndroidProject extends PlatformProject {
   }
 
   /**
+   * Get the Java file name of the main activity. Use `getMainActivityPath()` to get the
+   * name of the source file the project actually has, which can be a Kotlin one.
+   */
+  getMainActivityFilename(): string {
+    return `${this.getMainActivityName()}.java`;
+  }
+
+  async getMainActivityPath() {
+    const packageParts = (await this.getPackageName())?.split('.') ?? [];
+
+    return join('app', 'src', 'main', 'java', ...packageParts, await this.resolveMainActivityFilename());
+  }
+
+  /**
    * Get the file name of the main activity, with the source file extension the
    * project actually uses.
    */
-  async getMainActivityFilename(): Promise<string> {
+  private async resolveMainActivityFilename(): Promise<string> {
     const activityName = this.getMainActivityName();
-
-    if (!activityName) {
-      return '';
-    }
-
     const packageParts = (await this.getPackageName())?.split('.') ?? [];
     const kotlinActivity = `${activityName}.kt`;
 
@@ -359,20 +384,13 @@ export class AndroidProject extends PlatformProject {
     return `${activityName}.java`;
   }
 
-  async getMainActivityPath() {
-    const packageParts = (await this.getPackageName())?.split('.') ?? [];
-    const activityName = await this.getMainActivityFilename();
-
-    return join('app', 'src', 'main', 'java', ...packageParts, activityName);
-  }
-
   private getMainActivityName() {
     const activity =
       this.manifest.find(LAUNCHER_ACTIVITY)?.[0] ?? this.manifest.find('manifest/application/activity')?.[0];
 
     const activityName = activity?.getAttribute('android:name');
 
-    return activityName?.split('.').pop() ?? null;
+    return activityName?.split('.').pop() ?? DEFAULT_MAIN_ACTIVITY_NAME;
   }
 
   async getGradlePluginVersion() {

--- a/packages/project/src/ios/project.ts
+++ b/packages/project/src/ios/project.ts
@@ -1,5 +1,5 @@
 import plist from 'plist';
-import path, { extname, join, sep } from 'path';
+import path, { basename, extname, join, sep } from 'path';
 import { copy, pathExists, readdir, writeFile } from '@ionic/utils-fs';
 
 import { parsePbxProject, pbxReadString, pbxSerializeString } from "../util/pbx";
@@ -143,10 +143,10 @@ export class IosProject extends PlatformProject {
     targetName = this.assertTargetName(targetName);
 
     if (buildName) {
-      return this.getTarget(targetName)?.buildConfigurations.find(c => c.name === buildName)?.buildSettings?.['PRODUCT_BUNDLE_IDENTIFIER'];
+      return pbxReadString(this.getTarget(targetName)?.buildConfigurations.find(c => c.name === buildName)?.buildSettings?.['PRODUCT_BUNDLE_IDENTIFIER']);
     }
 
-    return this.getTarget(targetName)?.buildConfigurations[0]?.buildSettings?.['PRODUCT_BUNDLE_IDENTIFIER'];
+    return pbxReadString(this.getTarget(targetName)?.buildConfigurations[0]?.buildSettings?.['PRODUCT_BUNDLE_IDENTIFIER']);
   }
 
   /**
@@ -321,7 +321,7 @@ export class IosProject extends PlatformProject {
   getVersion(targetName: IosTargetName | null, buildName: IosBuildName | null) {
     targetName = this.assertTargetName(targetName || null);
 
-    return this.pbxProject?.getBuildProperty('MARKETING_VERSION', buildName ? buildName : undefined /* must use undefined if null */, targetName);
+    return pbxReadString(this.pbxProject?.getBuildProperty('MARKETING_VERSION', buildName ? buildName : undefined /* must use undefined if null */, targetName));
   }
 
   /**
@@ -585,7 +585,11 @@ export class IosProject extends PlatformProject {
   private addFileToBuildPhase(filePath: string, group: string | undefined) {
     const extension = extname(filePath);
 
-    if (extension === '.xcconfig') {
+    // Xcode copies a target's Info.plist into the bundle by itself, so copying it from the
+    // resources phase too fails the build with "Multiple commands produce Info.plist"
+    const belongsToNoBuildPhase = extension === '.xcconfig' || basename(filePath) === 'Info.plist';
+
+    if (belongsToNoBuildPhase) {
       this.pbxProject?.addFile(filePath, group);
     } else if (RESOURCE_FILE_EXTENSIONS.includes(extension)) {
       this.addResourceFile(filePath, group);
@@ -605,13 +609,18 @@ export class IosProject extends PlatformProject {
 
     const file = pbxProject.addFile(filePath, group);
 
+    // Without a target the pbx lib resolves whichever resources build phase comes first
+    // in the objects hash, which in a multi-target project can belong to an app extension
+    const appTargetId = this.getAppTarget()?.id;
+
     // A project without a resources build phase has nowhere to copy the file from, but
     // the file reference added above is still worth keeping
-    if (!file || !pbxProject.pbxResourcesBuildPhaseObj(undefined)) {
+    if (!file || !pbxProject.pbxResourcesBuildPhaseObj(appTargetId)) {
       return;
     }
 
     file.uuid = pbxProject.generateUuid();
+    file.target = appTargetId;
     pbxProject.addToPbxBuildFileSection(file);
     pbxProject.addToPbxResourcesBuildPhase(file);
   }

--- a/packages/project/src/xml.ts
+++ b/packages/project/src/xml.ts
@@ -74,13 +74,22 @@ export class XmlFile extends VFSStorable {
    * XPath 1.0, but acceptable here: prefixed name tests still resolve through the
    * namespaces collected from the root element, and without it an unprefixed target
    * matches nothing at all in a document that declares a default namespace.
+   *
+   * An expression that evaluates to a string, a number or a boolean selects nothing.
    */
   private select(expression: string, doc: Document): Node[] {
-    return (xpath as any).parse(expression).select({
+    const result = (xpath as any).parse(expression).evaluate({
       node: doc,
       namespaces: this.namespaces,
       allowAnyNamespaceForNoPrefix: true,
     });
+
+    if (!(result instanceof (xpath as any).XNodeSet)) {
+      Logger.warn(`The target '${expression}' in ${this.path} does not evaluate to nodes, only node-set expressions are supported`);
+      return [];
+    }
+
+    return result.toArray();
   }
 
   private selectTargetNodes(target: string, doc: Document): Element[] {
@@ -101,30 +110,37 @@ export class XmlFile extends VFSStorable {
     return this.select(target, this.doc) as Element[];
   }
 
-  deleteNodes(target: string) {
+  /**
+   * Modifies every node matching the target and flags the file as modified.
+   * A target that matches no node leaves the file untouched, so it isn't
+   * needlessly rewritten on commit.
+   */
+  private modifyTargetNodes(target: string, modify: (nodes: Element[]) => void) {
     if (!this.doc) {
       return;
     }
 
-    Logger.v('xml', 'deleteNodes', `at ${target}`);
-
     const nodes = this.selectTargetNodes(target, this.doc);
-    nodes.forEach(n => n.parentNode?.removeChild(n));
+
+    if (!nodes.length) {
+      return;
+    }
+
+    modify(nodes);
 
     this.vfs.set(this.path, this);
   }
 
+  deleteNodes(target: string) {
+    Logger.v('xml', 'deleteNodes', `at ${target}`);
+
+    this.modifyTargetNodes(target, nodes => nodes.forEach(n => n.parentNode?.removeChild(n)));
+  }
+
   deleteAttributes(target: string, attributes: string[]) {
-    if (!this.doc) {
-      return;
-    }
-
-    const nodes = this.selectTargetNodes(target, this.doc);
-    nodes.forEach(n => attributes.forEach(a => n.removeAttribute(a)));
-
     Logger.v('xml', 'deleteAttributes', `at ${target}`);
 
-    this.vfs.set(this.path, this);
+    this.modifyTargetNodes(target, nodes => nodes.forEach(n => attributes.forEach(a => n.removeAttribute(a))));
   }
 
   /**
@@ -133,58 +149,41 @@ export class XmlFile extends VFSStorable {
    * have the fragment appended.
    */
   injectFragment(target: string, fragment: string) {
-    if (!this.doc) {
-      return;
-    }
-
-    const nodes = this.selectTargetNodes(target, this.doc);
-    const docNodes = Array.from(parseXmlFragment(fragment, this.getNamespaceAttrs()));
-
     Logger.v('xml', 'injectFragment', `at ${target}`);
 
-    nodes.forEach(n =>
-      docNodes.forEach(d => n.appendChild(d)),
-    );
+    this.modifyTargetNodes(target, nodes => {
+      const docNodes = Array.from(parseXmlFragment(fragment, this.getNamespaceAttrs()));
 
-    this.vfs.set(this.path, this);
+      nodes.forEach(n =>
+        docNodes.forEach(d => n.appendChild(d)),
+      );
+    });
   }
 
   /**
    * Merges a fragment of XML into the given target.
    */
   mergeFragment(target: string, fragment: string) {
-    if (!this.doc) {
-      return;
-    }
-
-    // Get the target element
-    const node = this.selectTargetNodes(target, this.doc);
-
     Logger.v('xml', 'mergeFragment', `at ${target}`);
 
-    if (!node.length) {
-      return;
-    }
+    this.modifyTargetNodes(target, ([node]) => {
+      const targetSerialized = serializeXml(node);
+      const targetParsed = xml2js(targetSerialized.trim());
+      const fragmentParsed = xml2js(fragment.trim());
 
+      const newTree = this.mergeJsonTree(targetParsed, fragmentParsed);
 
-    const targetSerialized = serializeXml(node[0]);
-    const targetParsed = xml2js(targetSerialized.trim());
-    const fragmentParsed = xml2js(fragment.trim());
+      const xml = js2xml(newTree);
 
-    const newTree = this.mergeJsonTree(targetParsed, fragmentParsed);
+      const newTreeElement = parseXmlString(xml);
 
-    const xml = js2xml(newTree);
-
-    const newTreeElement = parseXmlString(xml);
-
-    for (const n of Array.prototype.slice.call(node[0].childNodes)) {
-      node[0].removeChild(n);
-    }
-    for (const n of Array.prototype.slice.call(newTreeElement.documentElement.childNodes)) {
-      node[0].appendChild(n);
-    }
-
-    this.vfs.set(this.path, this);
+      for (const n of Array.prototype.slice.call(node.childNodes)) {
+        node.removeChild(n);
+      }
+      for (const n of Array.prototype.slice.call(newTreeElement.documentElement.childNodes)) {
+        node.appendChild(n);
+      }
+    });
   }
 
   mergeJsonTree(target: any, fragment: any) {
@@ -232,26 +231,21 @@ export class XmlFile extends VFSStorable {
    * Replaces a given target with the given fragment
    */
   replaceFragment(target: string, fragment: string) {
-    if (!this.doc) {
-      return;
-    }
+    this.modifyTargetNodes(target, nodes => {
+      const parsed = parseXmlString(fragment);
 
-    const nodes = this.selectTargetNodes(target, this.doc);
-    const parsed = parseXmlString(fragment);
-
-    nodes.forEach(n => {
-      const index = Array.prototype.indexOf.call(n.parentNode?.childNodes, n);
-      if (index >= 0) {
-        const parent = n.parentNode;
-        parent!.removeChild(n);
-        parent!.insertBefore(
-          parsed.documentElement,
-          parent?.childNodes[index] ?? null,
-        );
-      }
+      nodes.forEach(n => {
+        const index = Array.prototype.indexOf.call(n.parentNode?.childNodes, n);
+        if (index >= 0) {
+          const parent = n.parentNode;
+          parent!.removeChild(n);
+          parent!.insertBefore(
+            parsed.documentElement,
+            parent?.childNodes[index] ?? null,
+          );
+        }
+      });
     });
-
-    this.vfs.set(this.path, this);
   }
 
   /**
@@ -260,20 +254,13 @@ export class XmlFile extends VFSStorable {
    * have its attributes modified
    */
   setAttrs(target: string, attrs: any) {
-    if (!this.doc) {
-      return;
-    }
-
     Logger.v('xml', 'setAttrs', `at ${this.path} - ${target}`);
 
-    const nodes = this.selectTargetNodes(target, this.doc);
-    nodes.forEach((n: any) => {
+    this.modifyTargetNodes(target, nodes => nodes.forEach(n => {
       Object.keys(attrs).forEach(attr => {
         n.setAttribute(attr, attrs[attr]);
       });
-    });
-
-    this.vfs.set(this.path, this);
+    }));
   }
 
   private xmlCommitFn = async (file: VFSFile) => {

--- a/packages/project/test/gradle-file.android.test.ts
+++ b/packages/project/test/gradle-file.android.test.ts
@@ -1,8 +1,8 @@
-import { AndroidGradleInjectType, MobileProject } from '../src';
+import { AndroidGradleInjectType, Logger, MobileProject } from '../src';
 import { MobileProjectConfig } from '../src/config';
 import { GradleFile, WINDOWS_GRADLE_PARSE_CLASSPATH } from '../src/android/gradle-file';
 
-import { readdir } from '@ionic/utils-fs';
+import { readdir, readFile } from '@ionic/utils-fs';
 import { join } from 'path';
 import { VFS } from '../src/vfs';
 
@@ -263,6 +263,17 @@ allprojects {
 }
 `.trim(),
     );
+  });
+
+  it('Should reject when inserting the replacement fails', async () => {
+    const gradle = new GradleFile(
+      join('../common/test/fixtures/replace.gradle'),
+      vfs,
+    );
+
+    await expect(
+      gradle.replaceProperties({ extra: {} }, { missing: undefined }),
+    ).rejects.toThrow(/Cannot convert undefined or null to object/);
   });
 
   it('Should replace assignments with a non-constant value without duplicating them', async () => {
@@ -798,6 +809,47 @@ intunemam {
 
     namespace = await gradle.getNamespace();
     expect(namespace).toBe('io.ionic.test');
+  });
+
+  // An app build.gradle can declare only a namespace, the applicationId then defaults
+  // to it and there is no defaultConfig block to set it in
+  it('Should warn instead of failing to set the applicationId without a defaultConfig block', async () => {
+    const warn = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+    const filename = join('../common/test/fixtures/no-default-config.gradle');
+    const gradle = new GradleFile(filename, vfs);
+
+    await gradle.setApplicationId('io.ionic.test');
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no android.defaultConfig block found'));
+    expect(vfs.get<GradleFile>(filename)?.isModified()).toBe(false);
+    expect(vfs.get<GradleFile>(filename)?.getData()?.getDocument()).toBe(
+      await readFile(filename, { encoding: 'utf-8' }),
+    );
+  });
+
+  it('Should get versions assigned with =', async () => {
+    const gradle = new GradleFile(
+      join('../common/test/fixtures/version-assignments.gradle'),
+      vfs,
+    );
+
+    expect(await gradle.getVersionCode()).toBe(4);
+    expect(await gradle.getVersionName()).toBe('1.0');
+    expect(await gradle.getVersionNameSuffix()).toBe('beta');
+  });
+
+  it('Should increment a version code assigned with =', async () => {
+    const gradle = new GradleFile(
+      join('../common/test/fixtures/version-assignments.gradle'),
+      vfs,
+    );
+
+    await gradle.incrementVersionCode();
+
+    expect(await gradle.getVersionCode()).toBe(5);
+    expect(
+      vfs.get<GradleFile>(gradle.filename)?.getData()?.getDocument(),
+    ).toContain('versionCode = 5');
   });
 
   it('Should inject into a block shadowed by an assignment of the same name', async () => {

--- a/packages/project/test/project.android.test.ts
+++ b/packages/project/test/project.android.test.ts
@@ -1,7 +1,7 @@
 import { MobileProject, XmlFile } from '../src';
 
 import { join } from 'path';
-import { pathExists, readFile, stat, writeFile } from '@ionic/utils-fs';
+import { mkdirp, pathExists, readFile, stat, writeFile } from '@ionic/utils-fs';
 import { formatXml, serializeXml } from "../src/util/xml";
 import { MobileProjectConfig } from '../src/config';
 import { GradleFile } from '../src/android/gradle-file';
@@ -34,7 +34,7 @@ describe('project - android', () => {
   });
 
   it('should get main activity filename', async () => {
-    expect(await project.android?.getMainActivityFilename()).toBe('MainActivity.java');
+    expect(project.android?.getMainActivityFilename()).toBe('MainActivity.java');
   });
 
   it('should get gradle plugin version', async () => {
@@ -438,7 +438,7 @@ describe('project - android - capacitor v8', () => {
   });
 
   it('should get main activity filename of the launcher activity', async () => {
-    expect(await project.android?.getMainActivityFilename()).toBe('MainActivity.java');
+    expect(project.android?.getMainActivityFilename()).toBe('MainActivity.java');
   });
 
   it('should set package name', async () => {
@@ -464,6 +464,38 @@ describe('project - android - capacitor v8', () => {
 
     const helperSource = await readFile(join(newPackageDir, 'sub/Helper.java'), { encoding: 'utf-8' });
     expect(helperSource).toContain('package com.ionicframework.awesome.sub;');
+  });
+
+  it('should rename the package declaration of a source that mentions a package in its header comment', async () => {
+    const sourceDir = join(androidDir, 'app/src/main/java');
+    await writeFile(join(sourceDir, 'io/ionic/starter/Documented.java'), `/*
+ * This package is part of the sample app.
+ */
+package io.ionic.starter;
+
+public class Documented {}
+`);
+
+    await project.android?.setPackageName('com.ionicframework.awesome');
+
+    const moved = await readFile(join(sourceDir, 'com/ionicframework/awesome/Documented.java'), { encoding: 'utf-8' });
+    expect(moved).toContain('package com.ionicframework.awesome;');
+    expect(moved).toContain('This package is part of the sample app.');
+  });
+
+  it('should not move any source when a file is in the way', async () => {
+    const sourceDir = join(androidDir, 'app/src/main/java');
+    const oldPackageDir = join(sourceDir, 'io/ionic/starter');
+    await mkdirp(join(sourceDir, 'com/ionicframework/awesome/sub'));
+    await writeFile(join(sourceDir, 'com/ionicframework/awesome/sub/Helper.java'), 'package com.ionicframework.awesome.sub;\n');
+
+    await expect(project.android?.setPackageName('com.ionicframework.awesome')).rejects.toThrow(
+      /a file already exists at/
+    );
+
+    expect(await pathExists(join(oldPackageDir, 'MainActivity.java'))).toBe(true);
+    expect(await pathExists(join(oldPackageDir, 'MyPlugin.java'))).toBe(true);
+    expect(await pathExists(join(oldPackageDir, 'sub/Helper.java'))).toBe(true);
   });
 
   it('should set a package name nested in the old package', async () => {
@@ -543,8 +575,9 @@ describe('project - android - kotlin', () => {
     androidDir = project.config.android?.path!;
   });
 
+  // The file name of the activity comes from the manifest, which has no extension in it
   it('should get main activity filename', async () => {
-    expect(await project.android?.getMainActivityFilename()).toBe('MainActivity.kt');
+    expect(project.android?.getMainActivityFilename()).toBe('MainActivity.java');
   });
 
   it('should get main activity path', async () => {

--- a/packages/project/test/project.ios.test.ts
+++ b/packages/project/test/project.ios.test.ts
@@ -78,6 +78,18 @@ describe('project - ios standard', () => {
     expect(releaseBundleId).toBe('io.ionic.betterBundleId');
   });
 
+  it('should round-trip a bundle id that has to be quoted in the pbxproj', async () => {
+    const ios = project.ios!;
+
+    ios.setBundleId('App', null, 'io.ionic.my-awesome-app');
+    expect(ios.getBundleId('App', 'Debug')).toBe('io.ionic.my-awesome-app');
+    expect(ios.getBundleId('App')).toBe('io.ionic.my-awesome-app');
+
+    // Writing back what was read must not add another layer of quoting
+    ios.setBundleId('App', null, ios.getBundleId('App')!);
+    expect(ios.getBundleId('App', 'Debug')).toBe('io.ionic.my-awesome-app');
+  });
+
   it('should get target product name', async () => {
     expect(project.ios?.getProductName('App')).toBe('App');
   });
@@ -129,6 +141,17 @@ describe('project - ios standard', () => {
     const filename = await project.ios?.getInfoPlistFilename('App', 'Debug');
     const updated = project.vfs.get<PlistFile>(filename!)?.getData();
     expect(updated?.getDocument()?.['CFBundleShortVersionString']).toBe('$(MARKETING_VERSION)');
+  });
+
+  it('should round-trip a version that has to be quoted in the pbxproj', async () => {
+    const ios = project.ios!;
+
+    await ios.setVersion('App', 'Debug', '1.0.0-beta.1');
+    expect(ios.getVersion('App', 'Debug')).toBe('1.0.0-beta.1');
+
+    // Writing back what was read must not add another layer of quoting
+    await ios.setVersion('App', 'Debug', ios.getVersion('App', 'Debug'));
+    expect(ios.getVersion('App', 'Debug')).toBe('1.0.0-beta.1');
   });
 
   it('should update build settings', async () => {
@@ -462,6 +485,7 @@ describe('project - ios standard', () => {
     await project.ios?.addFile('App/Brand.plist');
     await project.ios?.addFile('App/New.strings');
     await project.ios?.addFile('App/Build.xcconfig');
+    await project.ios?.addFile('My App Clip/Info.plist');
 
     await project.commit();
 
@@ -479,6 +503,30 @@ describe('project - ios standard', () => {
     expect(pbxOnDisk).toContain('Build.xcconfig');
     expect(resources).not.toContain('Build.xcconfig');
     expect(sources).not.toContain('Build.xcconfig');
+
+    // Xcode copies a target's Info.plist into the bundle itself, copying it from the
+    // resources phase too fails the build with "Multiple commands produce Info.plist"
+    expect(pbxOnDisk).toContain('My App Clip/Info.plist');
+    expect(resources).not.toContain('Info.plist');
+    expect(sources).not.toContain('Info.plist');
+  });
+
+  it('should add resource files to the resources build phase of the app target', async () => {
+    await project.ios?.addFile('App/New.strings');
+
+    const pbx = project.ios?.getPbxProject();
+    const resourcesPhases = pbx?.hash.project.objects['PBXResourcesBuildPhase'];
+    const appTarget = pbx?.pbxNativeTargetSection()[project.ios?.getAppTarget()?.id!];
+    const appResourcesPhaseId = appTarget.buildPhases.find((p: any) => p.comment === 'Resources').value;
+
+    const filesInPhase = (id: string) => resourcesPhases[id].files.map((f: any) => f.comment);
+
+    expect(filesInPhase(appResourcesPhaseId)).toContain('New.strings in Resources');
+
+    // Any other target (here: the app clip and the extensions) must be left alone
+    Object.keys(resourcesPhases)
+      .filter(id => id.indexOf('_comment') < 0 && id !== appResourcesPhaseId)
+      .forEach(id => expect(filesInPhase(id)).not.toContain('New.strings in Resources'));
   });
 
 });

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -189,6 +189,35 @@ describe('xml file', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining(`match the target 'missing'`));
   });
 
+  // A file that wasn't touched must not be committed, otherwise it is reformatted for nothing
+  describe('Targets that select no nodes', () => {
+    beforeEach(() => {
+      vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+    });
+
+    it('Should not modify the file when the target matches no nodes', async () => {
+      file.deleteNodes('//missing');
+
+      expect(vfs.modifiedFiles()).toHaveLength(0);
+    });
+
+    it('Should not modify the file when the target is not a node-set expression', async () => {
+      expect(() => file.deleteNodes('string(//string/@name)')).not.toThrow();
+
+      expect(vfs.modifiedFiles()).toHaveLength(0);
+    });
+
+    it('Should find nothing for a target that is not a node-set expression', async () => {
+      expect(file.find('string(//string/@name)')).toEqual([]);
+    });
+
+    it('Should modify the file when the target matches', async () => {
+      file.deleteNodes('//string');
+
+      expect(vfs.modifiedFiles()).toHaveLength(1);
+    });
+  });
+
   it('Should replace', async () => {
     file.replaceFragment('resources/string[@name="app_name"]', `
       <string name="app_name">$PRODUCT_NAME</string>


### PR DESCRIPTION
A pre-release review of all changes since `@trapezedev/*@7.1.8` (#245–#257) surfaced three high-severity regressions plus a set of medium findings. This PR fixes all of them before 7.1.9 ships.

## High-severity regressions

- **pbxproj values no longer round-trip broken**: the widened quoting rule stores hyphenated values quoted (correct), but `getBundleId()`/`getVersion()` read them back with literal quotes and re-setting compounded the escaping (`"\"io.ionic.my-app\""`). Both getters now unquote via `pbxReadString`, like `getBuildProperty` already did.
- **Literal `$`-prefixed YAML keys survive**: map-key interpolation rewrote any unresolvable `$word` key to `""`, corrupting e.g. a JSON `$schema` key. Keys are now only interpolated when every `$` reference resolves to a declared variable.
- **Gradle insert fallback is awaited**: `replaceProperty`'s insert path was fire-and-forget, so a failure escaped as an unhandled promise rejection after the operation had already reported success.

## Other fixes

- `setApplicationId` warns and no-ops (7.1.8 behavior, now visible) instead of aborting the whole run when `app/build.gradle` has no `defaultConfig` block; introduces `GradleTargetNotFound` so a missing target is distinguishable from a failed edit
- the package declaration regex is anchored, so a source file whose header comment mentions "package" is rewritten instead of silently skipped after being moved
- `movePackageSources` pre-flights every destination before the first move, so a file that is in the way can no longer leave the tree split across two package directories
- the Gradle version getters (`getVersionCode`/`getVersionName`/`getVersionNameSuffix`) accept `=`-style assignment, so `incrementVersionCode` works on AGP 8-style files; `versionCode\b` keeps `versionCodeOverride` from false-matching
- `getMainActivityFilename()` is sync again (the 7.1.8 public API contract); the `.kt` probe moved into `getMainActivityPath()`
- XML mutations no longer mark the file modified when the XPath matched nothing (no more spurious reformat commits), and non-node-set expressions (`string(...)`, `count(...)`) warn and select nothing instead of throwing
- a target's `Info.plist` gets a file reference only, never Copy Bundle Resources ("Multiple commands produce" build failure), and resource files are added to the app target's resources phase instead of whichever phase comes first in the objects hash
- a platform project that fails to load (e.g. corrupt pbxproj) sets `process.exitCode = 1` while the run continues, so CI notices dropped operations
- `engines` corrected to `>=18` (the code uses global `fetch`); `plist` declared as a configure devDependency instead of relying on hoisting
- the release workflow sets up Java, runs `typecheck` and the tarball smoke test before release-please cuts a tag, and builds on Node 20 to match CI
- the two near-timeout commit tests got explicit 120 s timeouts so a loaded runner cannot flake the release gate

## Verification

- Full suite green: `@trapezedev/project` 22 files / 203 tests, `@trapezedev/configure` all passing, root `typecheck` 3/3, `node scripts/smoke.mjs` passed
- Every behavioral fix is pinned by a new or updated test that fails without the source change
- New fixtures: `no-default-config.gradle`, `version-assignments.gradle`
