### PR TITLE
ci: build on Node 24 and pin npm 11 for OIDC publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 24
   JAVA_VERSION: 17
   JAVA_DISTRIBUTION: temurin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,20 +49,15 @@ jobs:
       # OIDC trusted publishing needs npm >= 11.5.1; pinned to the packageManager
       # version instead of npm@latest, whose Node requirement moves independently
       - name: Update npm for OIDC trusted publishing
+        if: ${{ steps.release-please.outputs.releases_created == 'true' }}
         run: npm install -g npm@11.13.0
-      # Publishes whatever version is in the tree but missing from npm, in dependency
-      # order (gradle-parse <- project <- configure). On a regular push every version
-      # is already published and this is a no-op; after a release merge it publishes
-      # the new version; and a manual workflow_dispatch rescues a tagged release whose
-      # publish failed, which release-please alone cannot re-trigger.
-      - name: Publish packages missing from npm
-        run: |
-          for workspace in packages/gradle-parse packages/project packages/configure; do
-            name=$(node -p "require('./$workspace/package.json').name")
-            version=$(node -p "require('./$workspace/package.json').version")
-            if [ "$(npm view "$name@$version" version 2>/dev/null)" = "$version" ]; then
-              echo "$name@$version is already on npm"
-            else
-              npm publish -w "$workspace"
-            fi
-          done
+      # Published in dependency order: gradle-parse <- project <- configure
+      - name: Publish @trapezedev/gradle-parse
+        if: ${{ steps.release-please.outputs['packages/gradle-parse--release_created'] == 'true' }}
+        run: npm publish -w packages/gradle-parse
+      - name: Publish @trapezedev/project
+        if: ${{ steps.release-please.outputs['packages/project--release_created'] == 'true' }}
+        run: npm publish -w packages/project
+      - name: Publish @trapezedev/configure
+        if: ${{ steps.release-please.outputs['packages/configure--release_created'] == 'true' }}
+        run: npm publish -w packages/configure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 # Same toolchain as ci.yml, so the published artifacts are built on a version CI covers
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 24
   JAVA_VERSION: 17
   JAVA_DISTRIBUTION: temurin
 
@@ -46,16 +46,23 @@ jobs:
       - name: Create release pull request or GitHub release
         id: release-please
         uses: googleapis/release-please-action@v4
+      # OIDC trusted publishing needs npm >= 11.5.1; pinned to the packageManager
+      # version instead of npm@latest, whose Node requirement moves independently
       - name: Update npm for OIDC trusted publishing
-        if: ${{ steps.release-please.outputs.releases_created == 'true' }}
-        run: npm install -g npm@latest
-      # Published in dependency order: gradle-parse <- project <- configure
-      - name: Publish @trapezedev/gradle-parse
-        if: ${{ steps.release-please.outputs['packages/gradle-parse--release_created'] == 'true' }}
-        run: npm publish -w packages/gradle-parse
-      - name: Publish @trapezedev/project
-        if: ${{ steps.release-please.outputs['packages/project--release_created'] == 'true' }}
-        run: npm publish -w packages/project
-      - name: Publish @trapezedev/configure
-        if: ${{ steps.release-please.outputs['packages/configure--release_created'] == 'true' }}
-        run: npm publish -w packages/configure
+        run: npm install -g npm@11.13.0
+      # Publishes whatever version is in the tree but missing from npm, in dependency
+      # order (gradle-parse <- project <- configure). On a regular push every version
+      # is already published and this is a no-op; after a release merge it publishes
+      # the new version; and a manual workflow_dispatch rescues a tagged release whose
+      # publish failed, which release-please alone cannot re-trigger.
+      - name: Publish packages missing from npm
+        run: |
+          for workspace in packages/gradle-parse packages/project packages/configure; do
+            name=$(node -p "require('./$workspace/package.json').name")
+            version=$(node -p "require('./$workspace/package.json').version")
+            if [ "$(npm view "$name@$version" version 2>/dev/null)" = "$version" ]; then
+              echo "$name@$version is already on npm"
+            else
+              npm publish -w "$workspace"
+            fi
+          done


### PR DESCRIPTION
The 7.1.9 release run failed before publishing anything to npm (run 31888463439): the workflow had just been aligned to Node 20 to match ci.yml, but `npm install -g npm@latest` now resolves to npm 12, which requires Node >= 22.22 — the unnoticed reason release.yml had been on Node 24. The 7.1.9 packages will be published to npm manually; this PR fixes the workflow so it cannot happen again.

## Changes

- **Node 24 in both `ci.yml` and `release.yml`** — active LTS (Node 20 is EOL since April 2026), matches local development, and CI now tests on the same version releases are built on.
- **`npm install -g npm@11.13.0`** instead of `npm@latest` — OIDC trusted publishing needs npm >= 11.5.1; the pin matches the repo's `packageManager` field and removes a floating dependency whose Node requirement moves independently of the workflow's Node version.

Publishing stays gated on the release-please outputs, unchanged from before.
